### PR TITLE
feat(led): multi-GPU slot cycling for PA120

### DIFF
--- a/src/trcc/adapters/system/linux/sensors.py
+++ b/src/trcc/adapters/system/linux/sensors.py
@@ -874,6 +874,44 @@ class SensorEnumerator(SensorEnumeratorABC):
 
         # Memory
         mapping['mem_temp'] = _find_first(source='hwmon', name_contains='spd') or ''
+
+    def gpu_mapping_for_pci(self, pci_slot: str) -> dict[str, str]:
+        """Build gpu_temp/usage/clock/power sensor IDs for a specific PCI slot.
+
+        Used by the LED cycle timer to pre-build mappings for all GPU slots
+        so switching is instant (no re-enumeration needed).
+        """
+        self._ensure_discovered()
+        for g in detect_gpus():
+            if g['pci_slot'] != pci_slot:
+                continue
+            v = g.get('vendor', '')
+            if v == _GPU_VENDOR_AMD:
+                drv = g.get('driver_key', 'amdgpu')
+                card = g.get('drm_card', '')
+                return {
+                    'gpu_temp': _find_first(source='hwmon', name_contains=drv, category='temperature') or '',
+                    'gpu_usage': _find_first(source='drm', name_contains=card, category='usage') or '' if card else '',
+                    'gpu_clock': _find_first(source='hwmon', name_contains=drv, category='clock') or '',
+                    'gpu_power': _find_first(source='hwmon', name_contains=drv, category='power') or '',
+                }
+            elif v == _GPU_VENDOR_NVIDIA:
+                # TODO: resolve nvidia_idx from PCI slot for multi-NVIDIA
+                prefix = f"nvidia:0"
+                return {
+                    'gpu_temp': f"{prefix}:temp",
+                    'gpu_usage': f"{prefix}:gpu_util",
+                    'gpu_clock': f"{prefix}:clock",
+                    'gpu_power': f"{prefix}:power",
+                }
+            elif v == _GPU_VENDOR_INTEL:
+                return {
+                    'gpu_temp': _find_first(source='hwmon', name_contains='i915', category='temperature') or '',
+                    'gpu_usage': '',
+                    'gpu_clock': _find_first(source='drm', category='clock') or '',
+                    'gpu_power': _find_first(source='hwmon', name_contains='i915', category='power') or '',
+                }
+        return {'gpu_temp': '', 'gpu_usage': '', 'gpu_clock': '', 'gpu_power': ''}
         mapping['mem_percent'] = 'psutil:mem_percent'
         mapping['mem_available'] = 'psutil:mem_available'
         mapping['mem_clock'] = ''  # No reliable Linux source

--- a/src/trcc/adapters/system/linux/sensors.py
+++ b/src/trcc/adapters/system/linux/sensors.py
@@ -815,8 +815,24 @@ class SensorEnumerator(SensorEnumeratorABC):
         mapping['cpu_freq'] = 'psutil:cpu_freq'
         mapping['cpu_power'] = _find_first(source='rapl') or ''
 
-        # GPU — pick best GPU by VRAM, fall back to vendor priority.
-        gpu = self._best_gpu()
+        # GPU — when gpu_slots are configured (cycle mode), use the active slot.
+        # Otherwise fall back to _best_gpu() auto-detection by VRAM.
+        from trcc.conf import load_config
+        config = load_config()
+        gpu_slots = config.get('gpu_slots', {})
+        if gpu_slots:
+            active_slot = config.get('gpu_active_slot', next(iter(gpu_slots), ''))
+            preferred_pci = gpu_slots.get(active_slot)
+            preferred_gpu = None
+            if preferred_pci:
+                for g in detect_gpus():
+                    if g['pci_slot'] == preferred_pci:
+                        preferred_gpu = g
+                        break
+            gpu = preferred_gpu or self._best_gpu()
+        else:
+            gpu = self._best_gpu()
+
         if gpu.get('vendor') == 'nvidia':
             prefix = f"nvidia:{gpu['nvidia_idx']}"
             mapping['gpu_temp'] = f"{prefix}:temp"
@@ -824,10 +840,10 @@ class SensorEnumerator(SensorEnumeratorABC):
             mapping['gpu_clock'] = f"{prefix}:clock"
             mapping['gpu_power'] = f"{prefix}:power"
         elif gpu.get('vendor') == 'amd':
-            drv = gpu['hwmon_driver']
-            card = gpu['drm_card']
+            drv = gpu.get('hwmon_driver', 'amdgpu')
+            card = gpu.get('drm_card', '')
             mapping['gpu_temp'] = _find_first(source='hwmon', name_contains=drv, category='temperature') or ''
-            mapping['gpu_usage'] = _find_first(source='drm', name_contains=card, category='usage') or ''
+            mapping['gpu_usage'] = _find_first(source='drm', name_contains=card, category='usage') or '' if card else ''
             mapping['gpu_clock'] = _find_first(source='hwmon', name_contains=drv, category='clock') or ''
             mapping['gpu_power'] = _find_first(source='hwmon', name_contains=drv, category='power') or ''
         elif _GPU_VENDOR_INTEL in _detect_gpu_vendors():

--- a/src/trcc/adapters/system/linux/sensors.py
+++ b/src/trcc/adapters/system/linux/sensors.py
@@ -822,38 +822,11 @@ class SensorEnumerator(SensorEnumeratorABC):
         mapping['cpu_freq'] = 'psutil:cpu_freq'
         mapping['cpu_power'] = _find_first(source='rapl') or ''
 
-        # GPU — when gpu_slots are configured (cycle mode), use the active slot.
-        # Otherwise fall back to _best_gpu() auto-detection by VRAM.
-        from trcc.conf import load_config
-        config = load_config()
-        gpu_slots = config.get('gpu_slots', {})
-        if gpu_slots:
-            active_slot = config.get('gpu_active_slot', next(iter(gpu_slots), ''))
-            preferred_pci = gpu_slots.get(active_slot)
-            gpu: dict = {}
-            if preferred_pci:
-                for g in detect_gpus():
-                    if g['pci_slot'] == preferred_pci:
-                        # Normalise detect_gpus() dict to _best_gpu() format:
-                        # vendor '1002' → 'amd', driver_key → hwmon_driver
-                        v = g.get('vendor', '')
-                        if v == _GPU_VENDOR_AMD:
-                            gpu = {'vendor': 'amd', 'nvidia_idx': None,
-                                   'drm_card': g.get('drm_card', ''),
-                                   'hwmon_driver': g.get('driver_key', 'amdgpu')}
-                        elif v == _GPU_VENDOR_NVIDIA:
-                            gpu = {'vendor': 'nvidia', 'nvidia_idx': 0,
-                                   'drm_card': g.get('drm_card', ''),
-                                   'hwmon_driver': g.get('driver_key', '')}
-                        elif v == _GPU_VENDOR_INTEL:
-                            gpu = {'vendor': 'intel', 'nvidia_idx': None,
-                                   'drm_card': g.get('drm_card', ''),
-                                   'hwmon_driver': g.get('driver_key', 'i915')}
-                        break
-            if not gpu:
-                gpu = self._best_gpu()
-        else:
-            gpu = self._best_gpu()
+        # GPU — pick best GPU by VRAM, fall back to vendor priority.
+        # When gpu_slots are configured, the LED cycle timer patches
+        # _defaults with per-slot sensor IDs via _swap_gpu_mapping(),
+        # so map_defaults only needs the initial best-GPU mapping.
+        gpu = self._best_gpu()
 
         if gpu.get('vendor') == 'nvidia':
             prefix = f"nvidia:{gpu['nvidia_idx']}"

--- a/src/trcc/adapters/system/linux/sensors.py
+++ b/src/trcc/adapters/system/linux/sensors.py
@@ -101,6 +101,104 @@ def _detect_gpu_vendors() -> list[str]:
     return vendors
 
 
+def detect_gpus() -> list[dict[str, str]]:
+    """Detect all GPUs with PCI slot, vendor, and human-readable name.
+
+    Returns list of dicts: {'pci_slot', 'vendor', 'name', 'driver_key', 'drm_card'}.
+    Name is resolved from the kernel's DRM device name or lspci output.
+    """
+    import subprocess
+
+    pci_base = Path('/sys/bus/pci/devices')
+    drm_base = Path('/sys/class/drm')
+    hwmon_base = Path('/sys/class/hwmon')
+    if not pci_base.exists():
+        return []
+
+    # Build PCI slot → lspci name mapping
+    pci_names: dict[str, str] = {}
+    try:
+        result = subprocess.run(
+            ['lspci', '-mm'], capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            import re
+            for line in result.stdout.splitlines():
+                # lspci -mm fields (quoted):
+                #   0=class, 1=vendor, 2=device, 3=SVendor (may be -), 4=SDevice
+                # e.g.: 06:00.0 "VGA..." "AMD..." "Navi 10 [Radeon...]" -rc1 -p00 "Sapphire..." "PULSE RX 7900 XTX"
+                match = re.match(r'^(\S+)\s+', line)
+                if match:
+                    slot = match.group(1)
+                    quoted = re.findall(r'"([^"]*)"', line)
+                    # Prefer subsystem device name (index 4), fall back to device (index 2)
+                    if len(quoted) >= 5 and quoted[4]:
+                        pci_names[slot] = quoted[4]
+                    elif len(quoted) >= 3:
+                        pci_names[slot] = quoted[2]
+    except (FileNotFoundError, OSError):
+        pass
+
+    # Build PCI device path → DRM card name mapping
+    pci_to_drm: dict[str, str] = {}
+    if drm_base.exists():
+        for card_dir in sorted(drm_base.glob('card[0-9]*')):
+            if '-' in card_dir.name:
+                continue
+            try:
+                dev_path = (card_dir / 'device').resolve()
+                pci_to_drm[str(dev_path)] = card_dir.name
+            except OSError:
+                continue
+
+    # Build PCI device path → hwmon driver_key mapping
+    pci_to_driver_key: dict[str, str] = {}
+    if hwmon_base.exists():
+        driver_counts: dict[str, int] = {}
+        for hwmon_dir in sorted(hwmon_base.iterdir()):
+            driver_name = SysUtils.read_sysfs(str(hwmon_dir / 'name')) or hwmon_dir.name
+            driver_counts[driver_name] = driver_counts.get(driver_name, 0) + 1
+            if driver_counts[driver_name] > 1:
+                driver_key = f"{driver_name}.{driver_counts[driver_name] - 1}"
+            else:
+                driver_key = driver_name
+            try:
+                dev_path = str((hwmon_dir / 'device').resolve())
+                pci_to_driver_key[dev_path] = driver_key
+            except OSError:
+                continue
+
+    gpus: list[dict[str, str]] = []
+    for dev_dir in sorted(pci_base.iterdir()):
+        class_path = dev_dir / 'class'
+        vendor_path = dev_dir / 'vendor'
+        if not class_path.exists() or not vendor_path.exists():
+            continue
+        try:
+            pci_class = class_path.read_text().strip()
+            if not (pci_class.startswith('0x0300') or pci_class.startswith('0x0302')):
+                continue
+            vendor = vendor_path.read_text().strip().removeprefix('0x')
+            pci_slot = dev_dir.name  # e.g. "0000:0f:00.0"
+            dev_resolved = str(dev_dir.resolve())
+
+            # Short slot for lspci lookup (strip domain prefix)
+            short_slot = pci_slot.split(':', 1)[1] if ':' in pci_slot else pci_slot
+            name = pci_names.get(short_slot, f"GPU [{vendor}] at {pci_slot}")
+
+            gpus.append({
+                'pci_slot': pci_slot,
+                'vendor': vendor,
+                'name': name,
+                'driver_key': pci_to_driver_key.get(dev_resolved, ''),
+                'drm_card': pci_to_drm.get(dev_resolved, ''),
+            })
+        except OSError:
+            continue
+
+    return gpus
+
+
 class SensorEnumerator(SensorEnumeratorABC):
     """Discovers and reads all available hardware sensors on Linux."""
 

--- a/src/trcc/adapters/system/linux/sensors.py
+++ b/src/trcc/adapters/system/linux/sensors.py
@@ -823,13 +823,28 @@ class SensorEnumerator(SensorEnumeratorABC):
         if gpu_slots:
             active_slot = config.get('gpu_active_slot', next(iter(gpu_slots), ''))
             preferred_pci = gpu_slots.get(active_slot)
-            preferred_gpu = None
+            gpu: dict = {}
             if preferred_pci:
                 for g in detect_gpus():
                     if g['pci_slot'] == preferred_pci:
-                        preferred_gpu = g
+                        # Normalise detect_gpus() dict to _best_gpu() format:
+                        # vendor '1002' → 'amd', driver_key → hwmon_driver
+                        v = g.get('vendor', '')
+                        if v == _GPU_VENDOR_AMD:
+                            gpu = {'vendor': 'amd', 'nvidia_idx': None,
+                                   'drm_card': g.get('drm_card', ''),
+                                   'hwmon_driver': g.get('driver_key', 'amdgpu')}
+                        elif v == _GPU_VENDOR_NVIDIA:
+                            gpu = {'vendor': 'nvidia', 'nvidia_idx': 0,
+                                   'drm_card': g.get('drm_card', ''),
+                                   'hwmon_driver': g.get('driver_key', '')}
+                        elif v == _GPU_VENDOR_INTEL:
+                            gpu = {'vendor': 'intel', 'nvidia_idx': None,
+                                   'drm_card': g.get('drm_card', ''),
+                                   'hwmon_driver': g.get('driver_key', 'i915')}
                         break
-            gpu = preferred_gpu or self._best_gpu()
+            if not gpu:
+                gpu = self._best_gpu()
         else:
             gpu = self._best_gpu()
 
@@ -846,7 +861,7 @@ class SensorEnumerator(SensorEnumeratorABC):
             mapping['gpu_usage'] = _find_first(source='drm', name_contains=card, category='usage') or '' if card else ''
             mapping['gpu_clock'] = _find_first(source='hwmon', name_contains=drv, category='clock') or ''
             mapping['gpu_power'] = _find_first(source='hwmon', name_contains=drv, category='power') or ''
-        elif _GPU_VENDOR_INTEL in _detect_gpu_vendors():
+        elif gpu.get('vendor') == 'intel':
             mapping['gpu_temp'] = _find_first(source='hwmon', name_contains='i915', category='temperature') or ''
             mapping['gpu_usage'] = ''
             mapping['gpu_clock'] = _find_first(source='drm', category='clock') or ''

--- a/src/trcc/adapters/system/linux/sensors.py
+++ b/src/trcc/adapters/system/linux/sensors.py
@@ -778,6 +778,21 @@ class SensorEnumerator(SensorEnumeratorABC):
 
     _default_map: Optional[dict[str, str]] = None
 
+    @staticmethod
+    def _find_first_sensor(sensors: list, source: str = '',
+                           name_contains: str = '',
+                           category: str = '') -> Optional[str]:
+        """Find the first sensor ID matching the given filters."""
+        for s in sensors:
+            if source and s.source != source:
+                continue
+            if category and s.category != category:
+                continue
+            if name_contains and name_contains.lower() not in s.name.lower():
+                continue
+            return s.id
+        return None
+
     def map_defaults(self) -> dict[str, str]:
         """Build a mapping from legacy metric keys to sensor IDs.
 
@@ -793,15 +808,7 @@ class SensorEnumerator(SensorEnumeratorABC):
 
         def _find_first(source: str = '', name_contains: str = '',
                         category: str = '') -> Optional[str]:
-            for s in sensors:
-                if source and s.source != source:
-                    continue
-                if category and s.category != category:
-                    continue
-                if name_contains and name_contains.lower() not in s.name.lower():
-                    continue
-                return s.id
-            return None
+            return self._find_first_sensor(sensors, source, name_contains, category)
 
         # CPU
         mapping['cpu_temp'] = (
@@ -874,44 +881,6 @@ class SensorEnumerator(SensorEnumeratorABC):
 
         # Memory
         mapping['mem_temp'] = _find_first(source='hwmon', name_contains='spd') or ''
-
-    def gpu_mapping_for_pci(self, pci_slot: str) -> dict[str, str]:
-        """Build gpu_temp/usage/clock/power sensor IDs for a specific PCI slot.
-
-        Used by the LED cycle timer to pre-build mappings for all GPU slots
-        so switching is instant (no re-enumeration needed).
-        """
-        self._ensure_discovered()
-        for g in detect_gpus():
-            if g['pci_slot'] != pci_slot:
-                continue
-            v = g.get('vendor', '')
-            if v == _GPU_VENDOR_AMD:
-                drv = g.get('driver_key', 'amdgpu')
-                card = g.get('drm_card', '')
-                return {
-                    'gpu_temp': _find_first(source='hwmon', name_contains=drv, category='temperature') or '',
-                    'gpu_usage': _find_first(source='drm', name_contains=card, category='usage') or '' if card else '',
-                    'gpu_clock': _find_first(source='hwmon', name_contains=drv, category='clock') or '',
-                    'gpu_power': _find_first(source='hwmon', name_contains=drv, category='power') or '',
-                }
-            elif v == _GPU_VENDOR_NVIDIA:
-                # TODO: resolve nvidia_idx from PCI slot for multi-NVIDIA
-                prefix = f"nvidia:0"
-                return {
-                    'gpu_temp': f"{prefix}:temp",
-                    'gpu_usage': f"{prefix}:gpu_util",
-                    'gpu_clock': f"{prefix}:clock",
-                    'gpu_power': f"{prefix}:power",
-                }
-            elif v == _GPU_VENDOR_INTEL:
-                return {
-                    'gpu_temp': _find_first(source='hwmon', name_contains='i915', category='temperature') or '',
-                    'gpu_usage': '',
-                    'gpu_clock': _find_first(source='drm', category='clock') or '',
-                    'gpu_power': _find_first(source='hwmon', name_contains='i915', category='power') or '',
-                }
-        return {'gpu_temp': '', 'gpu_usage': '', 'gpu_clock': '', 'gpu_power': ''}
         mapping['mem_percent'] = 'psutil:mem_percent'
         mapping['mem_available'] = 'psutil:mem_available'
         mapping['mem_clock'] = ''  # No reliable Linux source
@@ -961,6 +930,45 @@ class SensorEnumerator(SensorEnumeratorABC):
         # Remove empty mappings and cache
         SensorEnumerator._default_map = {k: v for k, v in mapping.items() if v}
         return SensorEnumerator._default_map
+
+    def gpu_mapping_for_pci(self, pci_slot: str) -> dict[str, str]:
+        """Build gpu_temp/usage/clock/power sensor IDs for a specific PCI slot.
+
+        Used by the LED cycle timer to pre-build mappings for all GPU slots
+        so switching is instant (no re-enumeration needed).
+        """
+        sensors = self.get_sensors()
+        _find = self._find_first_sensor
+        for g in detect_gpus():
+            if g['pci_slot'] != pci_slot:
+                continue
+            v = g.get('vendor', '')
+            if v == _GPU_VENDOR_AMD:
+                drv = g.get('driver_key', 'amdgpu')
+                card = g.get('drm_card', '')
+                return {
+                    'gpu_temp': _find(sensors, source='hwmon', name_contains=drv, category='temperature') or '',
+                    'gpu_usage': _find(sensors, source='drm', name_contains=card, category='usage') or '' if card else '',
+                    'gpu_clock': _find(sensors, source='hwmon', name_contains=drv, category='clock') or '',
+                    'gpu_power': _find(sensors, source='hwmon', name_contains=drv, category='power') or '',
+                }
+            elif v == _GPU_VENDOR_NVIDIA:
+                # TODO: resolve nvidia_idx from PCI slot for multi-NVIDIA
+                prefix = "nvidia:0"
+                return {
+                    'gpu_temp': f"{prefix}:temp",
+                    'gpu_usage': f"{prefix}:gpu_util",
+                    'gpu_clock': f"{prefix}:clock",
+                    'gpu_power': f"{prefix}:power",
+                }
+            elif v == _GPU_VENDOR_INTEL:
+                return {
+                    'gpu_temp': _find(sensors, source='hwmon', name_contains='i915', category='temperature') or '',
+                    'gpu_usage': '',
+                    'gpu_clock': _find(sensors, source='drm', category='clock') or '',
+                    'gpu_power': _find(sensors, source='hwmon', name_contains='i915', category='power') or '',
+                }
+        return {'gpu_temp': '', 'gpu_usage': '', 'gpu_clock': '', 'gpu_power': ''}
 
 
 # Backward-compat alias

--- a/src/trcc/adapters/system/linux/sensors.py
+++ b/src/trcc/adapters/system/linux/sensors.py
@@ -952,22 +952,15 @@ class SensorEnumerator(SensorEnumeratorABC):
                     'gpu_clock': _find(sensors, source='hwmon', name_contains=drv, category='clock') or '',
                     'gpu_power': _find(sensors, source='hwmon', name_contains=drv, category='power') or '',
                 }
-            elif v == _GPU_VENDOR_NVIDIA:
-                # TODO: resolve nvidia_idx from PCI slot for multi-NVIDIA
-                prefix = "nvidia:0"
-                return {
-                    'gpu_temp': f"{prefix}:temp",
-                    'gpu_usage': f"{prefix}:gpu_util",
-                    'gpu_clock': f"{prefix}:clock",
-                    'gpu_power': f"{prefix}:power",
-                }
-            elif v == _GPU_VENDOR_INTEL:
-                return {
-                    'gpu_temp': _find(sensors, source='hwmon', name_contains='i915', category='temperature') or '',
-                    'gpu_usage': '',
-                    'gpu_clock': _find(sensors, source='drm', category='clock') or '',
-                    'gpu_power': _find(sensors, source='hwmon', name_contains='i915', category='power') or '',
-                }
+            # NVIDIA: resolve nvidia_idx from PCI slot via
+            # pynvml.nvmlDeviceGetHandleByPciBusId(pci_slot), then use
+            # pynvml.nvmlDeviceGetIndex(handle) to build "nvidia:{idx}:*"
+            # sensor IDs.  Same pattern as AMD — one mapping per PCI slot.
+            #
+            # Intel: multi-GPU is uncommon, but the same approach works —
+            # match i915 hwmon instances by resolving /sys/class/drm/cardN
+            # → PCI device path, then filter _find() by that card's hwmon
+            # name (e.g. 'i915' vs 'i915.1', same as AMD's driver_key).
         return {'gpu_temp': '', 'gpu_usage': '', 'gpu_clock': '', 'gpu_power': ''}
 
 

--- a/src/trcc/cli/__init__.py
+++ b/src/trcc/cli/__init__.py
@@ -916,6 +916,13 @@ def _cmd_perf(
     return 0 if report.all_passed else 1
 
 
+@app.command("set-gpu", rich_help_panel="System")
+@_cli_handler
+def _cmd_set_gpu() -> int:
+    """Select which GPU to monitor (for multi-GPU systems)."""
+    return _system.set_gpu()
+
+
 @app.command("setup", rich_help_panel="System")
 def _cmd_setup(
     yes: Annotated[bool, typer.Option(

--- a/src/trcc/cli/_system.py
+++ b/src/trcc/cli/_system.py
@@ -381,7 +381,12 @@ def set_gpu() -> int:
     except (EOFError, KeyboardInterrupt):
         print()
         return 1
-    cycle_seconds = int(freq_input) if freq_input.isdigit() and int(freq_input) > 0 else 5
+    if freq_input.isdigit() and 1 <= int(freq_input) <= 300:
+        cycle_seconds = int(freq_input)
+    else:
+        cycle_seconds = 5
+        if freq_input:
+            print(f"  Invalid (must be 1-300s), using {cycle_seconds}s.")
 
     # Indicator color
     named_colors = {

--- a/src/trcc/cli/_system.py
+++ b/src/trcc/cli/_system.py
@@ -12,13 +12,10 @@ from trcc.core.platform import LINUX, detect_install_method, is_root
 
 log = logging.getLogger(__name__)
 
-if LINUX:
-    from trcc.adapters.system.linux.sensors import SensorEnumerator, detect_gpus  # noqa: E402
-    from trcc.conf import Settings
-else:
-    detect_gpus = None  # type: ignore[assignment]
-    SensorEnumerator = None  # type: ignore[assignment]
-    Settings = None  # type: ignore[assignment]
+# Patching stubs — real imports happen lazily inside set_gpu() (Linux only)
+detect_gpus = None  # type: ignore[assignment]
+SensorEnumerator = None  # type: ignore[assignment]
+Settings = None  # type: ignore[assignment]
 
 
 def _require_linux(command: str) -> int | None:
@@ -327,6 +324,12 @@ def set_gpu() -> int:
     if not LINUX:
         print("GPU selection is currently supported on Linux only.")
         return 1
+
+    global detect_gpus, SensorEnumerator, Settings
+    if detect_gpus is None:
+        from trcc.adapters.system.linux.sensors import detect_gpus, SensorEnumerator
+    if Settings is None:
+        from trcc.conf import Settings
 
     gpus = detect_gpus()
     if not gpus:

--- a/src/trcc/cli/_system.py
+++ b/src/trcc/cli/_system.py
@@ -312,3 +312,52 @@ def run_setup(auto_yes: bool = False) -> int:
     """Interactive setup wizard — dispatches to platform-specific adapter."""
     from trcc.core.app import TrccApp
     return TrccApp.get().setup_platform(auto_yes=auto_yes)
+
+
+def set_gpu() -> int:
+    """Interactive GPU selector for multi-GPU systems."""
+    from trcc.core.platform import LINUX
+    if not LINUX:
+        print("GPU selection is currently supported on Linux only.")
+        return 1
+
+    from trcc.adapters.system.linux.sensors import detect_gpus
+    from trcc.conf import Settings
+
+    gpus = detect_gpus()
+    if not gpus:
+        print("No GPUs detected.")
+        return 1
+
+    if len(gpus) == 1:
+        print(f"Only one GPU detected: {gpus[0]['name']}")
+        print("No selection needed.")
+        return 0
+
+    current = Settings._get_saved_gpu_pci_slot()
+
+    print("Detected GPUs:\n")
+    for i, gpu in enumerate(gpus, 1):
+        marker = " ← current" if gpu['pci_slot'] == current else ""
+        print(f"  {i}) {gpu['name']}{marker}")
+
+    print()
+    try:
+        choice = input("Select GPU [1-{}]: ".format(len(gpus))).strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return 1
+
+    try:
+        idx = int(choice) - 1
+        if not (0 <= idx < len(gpus)):
+            raise ValueError
+    except ValueError:
+        print("Invalid selection.")
+        return 1
+
+    selected = gpus[idx]
+    Settings.set_gpu(selected['pci_slot'])
+    print(f"\nGPU set to: {selected['name']}")
+    print("Restart trcc for the change to take effect.")
+    return 0

--- a/src/trcc/cli/_system.py
+++ b/src/trcc/cli/_system.py
@@ -321,7 +321,7 @@ def set_gpu() -> int:
         print("GPU selection is currently supported on Linux only.")
         return 1
 
-    from trcc.adapters.system.linux.sensors import detect_gpus
+    from trcc.adapters.system.linux.sensors import detect_gpus, SensorEnumerator
     from trcc.conf import Settings
 
     gpus = detect_gpus()
@@ -358,6 +358,7 @@ def set_gpu() -> int:
 
     selected = gpus[idx]
     Settings.set_gpu(selected['pci_slot'])
+    SensorEnumerator._default_map = None
     print(f"\nGPU set to: {selected['name']}")
     print("Restart trcc for the change to take effect.")
     return 0

--- a/src/trcc/cli/_system.py
+++ b/src/trcc/cli/_system.py
@@ -12,10 +12,6 @@ from trcc.core.platform import LINUX, detect_install_method, is_root
 
 log = logging.getLogger(__name__)
 
-# Patching stubs — real imports happen lazily inside set_gpu() (Linux only)
-detect_gpus = None  # type: ignore[assignment]
-SensorEnumerator = None  # type: ignore[assignment]
-Settings = None  # type: ignore[assignment]
 
 
 def _require_linux(command: str) -> int | None:
@@ -325,11 +321,8 @@ def set_gpu() -> int:
         print("GPU selection is currently supported on Linux only.")
         return 1
 
-    global detect_gpus, SensorEnumerator, Settings
-    if detect_gpus is None:
-        from trcc.adapters.system.linux.sensors import detect_gpus, SensorEnumerator
-    if Settings is None:
-        from trcc.conf import Settings
+    from trcc.adapters.system.linux.sensors import detect_gpus, SensorEnumerator
+    from trcc.conf import Settings
 
     gpus = detect_gpus()
     if not gpus:

--- a/src/trcc/cli/_system.py
+++ b/src/trcc/cli/_system.py
@@ -384,7 +384,40 @@ def set_gpu() -> int:
         return 1
     cycle_seconds = int(freq_input) if freq_input.isdigit() and int(freq_input) > 0 else 5
 
+    # Indicator color
+    named_colors = {
+        'red': '#FF0000', 'green': '#00FF00', 'blue': '#0000FF',
+        'yellow': '#FFFF00', 'cyan': '#00FFFF', 'magenta': '#FF00FF',
+        'white': '#FFFFFF', 'orange': '#FFA500', 'purple': '#800080',
+        'pink': '#FFC0CB', 'lime': '#00FF00', 'teal': '#008080',
+        'aqua': '#00FFFF', 'coral': '#FF7F50', 'gold': '#FFD700',
+        'violet': '#EE82EE', 'indigo': '#4B0082', 'crimson': '#DC143C',
+        'turquoise': '#40E0D0', 'salmon': '#FA8072',
+    }
+    current_color = Settings._get_saved_gpu_indicator_color()
+    try:
+        color_input = input(
+            f"\nIndicator color — name or hex (enter for {current_color}): "
+        ).strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return 1
+    if color_input:
+        lowered = color_input.lower()
+        if lowered in named_colors:
+            indicator_color = named_colors[lowered]
+        else:
+            raw = color_input.lstrip('#')
+            if len(raw) == 6 and all(c in '0123456789abcdefABCDEF' for c in raw):
+                indicator_color = f"#{raw.upper()}"
+            else:
+                print(f"  Unknown color '{color_input}', using {current_color}.")
+                indicator_color = current_color
+    else:
+        indicator_color = current_color
+
     Settings.set_gpu_slots(slots, cycle_seconds)
+    Settings.set_gpu_indicator_color(indicator_color)
     first_slot_pci = next(iter(slots.values()))
     Settings.set_gpu(first_slot_pci)
     SensorEnumerator._default_map = None
@@ -398,5 +431,6 @@ def set_gpu() -> int:
                 break
         print(f"  {slot}: {name}")
     print(f"Cycle: every {cycle_seconds}s")
+    print(f"Indicator color: {indicator_color}")
     print("Restart trcc for the change to take effect.")
     return 0

--- a/src/trcc/cli/_system.py
+++ b/src/trcc/cli/_system.py
@@ -362,6 +362,8 @@ def set_gpu() -> int:
             return 1
 
         if not choice:
+            if current_pci:
+                slots[slot] = current_pci
             continue
         try:
             idx = int(choice) - 1

--- a/src/trcc/cli/_system.py
+++ b/src/trcc/cli/_system.py
@@ -12,6 +12,14 @@ from trcc.core.platform import LINUX, detect_install_method, is_root
 
 log = logging.getLogger(__name__)
 
+if LINUX:
+    from trcc.adapters.system.linux.sensors import SensorEnumerator, detect_gpus  # noqa: E402
+    from trcc.conf import Settings
+else:
+    detect_gpus = None  # type: ignore[assignment]
+    SensorEnumerator = None  # type: ignore[assignment]
+    Settings = None  # type: ignore[assignment]
+
 
 def _require_linux(command: str) -> int | None:
     """Return error code if not on Linux, None if OK to proceed."""
@@ -316,13 +324,9 @@ def run_setup(auto_yes: bool = False) -> int:
 
 def set_gpu() -> int:
     """Interactive GPU selector for multi-GPU systems."""
-    from trcc.core.platform import LINUX
     if not LINUX:
         print("GPU selection is currently supported on Linux only.")
         return 1
-
-    from trcc.adapters.system.linux.sensors import detect_gpus, SensorEnumerator
-    from trcc.conf import Settings
 
     gpus = detect_gpus()
     if not gpus:
@@ -332,33 +336,71 @@ def set_gpu() -> int:
     if len(gpus) == 1:
         print(f"Only one GPU detected: {gpus[0]['name']}")
         print("No selection needed.")
+        Settings.set_gpu(gpus[0]['pci_slot'])
+        SensorEnumerator._default_map = None
         return 0
 
-    current = Settings._get_saved_gpu_pci_slot()
-
+    # Multi-GPU: assign to slots
     print("Detected GPUs:\n")
     for i, gpu in enumerate(gpus, 1):
-        marker = " ← current" if gpu['pci_slot'] == current else ""
-        print(f"  {i}) {gpu['name']}{marker}")
+        print(f"  {i}) {gpu['name']}")
 
-    print()
+    current_slots = Settings._get_saved_gpu_slots()
+    slot_names = ["top", "middle", "bottom"]
+    slots: dict[str, str] = {}
+
+    print("\nAssign GPUs to indicator slots (enter to skip):\n")
+    for slot in slot_names:
+        current_pci = current_slots.get(slot)
+        current_label = ""
+        if current_pci:
+            for g in gpus:
+                if g['pci_slot'] == current_pci:
+                    current_label = f" ← current: {g['name']}"
+                    break
+
+        try:
+            choice = input(f"  {slot.capitalize()} slot [1-{len(gpus)}]{current_label}: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 1
+
+        if not choice:
+            continue
+        try:
+            idx = int(choice) - 1
+            if not (0 <= idx < len(gpus)):
+                raise ValueError
+        except ValueError:
+            print(f"  Skipping {slot} (invalid input).")
+            continue
+        slots[slot] = gpus[idx]['pci_slot']
+
+    if not slots:
+        print("\nNo slots assigned.")
+        return 1
+
+    # Cycle frequency
     try:
-        choice = input("Select GPU [1-{}]: ".format(len(gpus))).strip()
+        freq_input = input("\nCycle frequency in seconds (enter for 5s): ").strip()
     except (EOFError, KeyboardInterrupt):
         print()
         return 1
+    cycle_seconds = int(freq_input) if freq_input.isdigit() and int(freq_input) > 0 else 5
 
-    try:
-        idx = int(choice) - 1
-        if not (0 <= idx < len(gpus)):
-            raise ValueError
-    except ValueError:
-        print("Invalid selection.")
-        return 1
-
-    selected = gpus[idx]
-    Settings.set_gpu(selected['pci_slot'])
+    Settings.set_gpu_slots(slots, cycle_seconds)
+    first_slot_pci = next(iter(slots.values()))
+    Settings.set_gpu(first_slot_pci)
     SensorEnumerator._default_map = None
-    print(f"\nGPU set to: {selected['name']}")
+
+    print("\nGPU slots configured:")
+    for slot, pci in slots.items():
+        name = pci
+        for g in gpus:
+            if g['pci_slot'] == pci:
+                name = g['name']
+                break
+        print(f"  {slot}: {name}")
+    print(f"Cycle: every {cycle_seconds}s")
     print("Restart trcc for the change to take effect.")
     return 0

--- a/src/trcc/cli/_system.py
+++ b/src/trcc/cli/_system.py
@@ -13,7 +13,6 @@ from trcc.core.platform import LINUX, detect_install_method, is_root
 log = logging.getLogger(__name__)
 
 
-
 def _require_linux(command: str) -> int | None:
     """Return error code if not on Linux, None if OK to proceed."""
     if not LINUX:
@@ -321,7 +320,7 @@ def set_gpu() -> int:
         print("GPU selection is currently supported on Linux only.")
         return 1
 
-    from trcc.adapters.system.linux.sensors import detect_gpus, SensorEnumerator
+    from trcc.adapters.system.linux.sensors import detect_gpus
     from trcc.conf import Settings
 
     gpus = detect_gpus()
@@ -331,9 +330,7 @@ def set_gpu() -> int:
 
     if len(gpus) == 1:
         print(f"Only one GPU detected: {gpus[0]['name']}")
-        print("No selection needed.")
-        Settings.set_gpu(gpus[0]['pci_slot'])
-        SensorEnumerator._default_map = None
+        print("Auto-detected by VRAM — no slot assignment needed.")
         return 0
 
     # Multi-GPU: assign to slots
@@ -420,9 +417,6 @@ def set_gpu() -> int:
 
     Settings.set_gpu_slots(slots, cycle_seconds)
     Settings.set_gpu_indicator_color(indicator_color)
-    first_slot_pci = next(iter(slots.values()))
-    Settings.set_gpu(first_slot_pci)
-    SensorEnumerator._default_map = None
 
     print("\nGPU slots configured:")
     for slot, pci in slots.items():

--- a/src/trcc/conf.py
+++ b/src/trcc/conf.py
@@ -573,17 +573,8 @@ class Settings:
 
     @staticmethod
     def set_gpu(pci_slot: str | None) -> None:
-        """Set preferred GPU by PCI slot (e.g. '0000:0f:00.0') and persist.
-
-        Invalidates the sensor default map cache so the new GPU takes effect.
-        """
+        """Set preferred GPU by PCI slot (e.g. '0000:0f:00.0') and persist."""
         Settings._save_gpu_pci_slot(pci_slot)
-        # Invalidate cached sensor mapping so next read uses the new GPU
-        try:
-            from trcc.adapters.system.linux.sensors import SensorEnumerator
-            SensorEnumerator._default_map = None
-        except ImportError:
-            pass
 
     @property
     def lang(self) -> str:

--- a/src/trcc/conf.py
+++ b/src/trcc/conf.py
@@ -350,38 +350,9 @@ class Settings:
         return load_config().get('gpu_slots', {})
 
     @staticmethod
-    def _save_gpu_slots(slots: dict[str, str]):
-        """Persist GPU slot assignments."""
-        config = load_config()
-        if not slots:
-            config.pop('gpu_slots', None)
-        else:
-            config['gpu_slots'] = slots
-        save_config(config)
-
-    @staticmethod
-    def _get_saved_gpu_cycle_seconds() -> int:
-        """Get GPU cycle interval in seconds. Defaults to 5."""
-        return int(load_config().get('gpu_cycle_seconds', 5))
-
-    @staticmethod
-    def _save_gpu_cycle_seconds(seconds: int):
-        """Persist GPU cycle interval."""
-        config = load_config()
-        config['gpu_cycle_seconds'] = seconds
-        save_config(config)
-
-    @staticmethod
     def _get_saved_gpu_indicator_color() -> str:
         """Get GPU indicator LED color as hex. Defaults to pure blue."""
         return load_config().get('gpu_indicator_color', '#0000FF')
-
-    @staticmethod
-    def _save_gpu_indicator_color(color: str):
-        """Persist GPU indicator LED color."""
-        config = load_config()
-        config['gpu_indicator_color'] = color
-        save_config(config)
 
     @staticmethod
     def _get_saved_refresh_interval() -> int:
@@ -615,13 +586,20 @@ class Settings:
     @staticmethod
     def set_gpu_indicator_color(color: str) -> None:
         """Set GPU indicator LED color (hex) and persist."""
-        Settings._save_gpu_indicator_color(color)
+        config = load_config()
+        config['gpu_indicator_color'] = color
+        save_config(config)
 
     @staticmethod
     def set_gpu_slots(slots: dict[str, str], cycle_seconds: int) -> None:
         """Set GPU slot assignments (multi-GPU cycle mode) and persist."""
-        Settings._save_gpu_slots(slots)
-        Settings._save_gpu_cycle_seconds(cycle_seconds)
+        config = load_config()
+        if slots:
+            config['gpu_slots'] = slots
+        else:
+            config.pop('gpu_slots', None)
+        config['gpu_cycle_seconds'] = cycle_seconds
+        save_config(config)
 
     @property
     def lang(self) -> str:

--- a/src/trcc/conf.py
+++ b/src/trcc/conf.py
@@ -616,7 +616,12 @@ class Settings:
         Settings._save_gpu_pci_slot(pci_slot)
 
     @staticmethod
-    def set_gpu_slots(slots: dict[str, str], cycle_seconds: int = 5) -> None:
+    def set_gpu_indicator_color(color: str) -> None:
+        """Set GPU indicator LED color (hex) and persist."""
+        Settings._save_gpu_indicator_color(color)
+
+    @staticmethod
+    def set_gpu_slots(slots: dict[str, str], cycle_seconds: int) -> None:
         """Set GPU slot assignments (multi-GPU cycle mode) and persist."""
         Settings._save_gpu_slots(slots)
         Settings._save_gpu_cycle_seconds(cycle_seconds)

--- a/src/trcc/conf.py
+++ b/src/trcc/conf.py
@@ -26,6 +26,8 @@ import json
 import locale
 import logging
 import os
+import tempfile
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
@@ -44,6 +46,7 @@ log = logging.getLogger(__name__)
 
 CONFIG_DIR = USER_CONFIG_DIR
 CONFIG_PATH = os.path.join(CONFIG_DIR, 'config.json')
+_config_lock = threading.Lock()
 
 # USBLCD (SCSI/RGB565) supported resolutions
 SUPPORTED_RESOLUTIONS = [
@@ -141,29 +144,43 @@ def _migrate_device_keys(config: dict) -> bool:
 def load_config() -> dict:
     """Load user config from disk. Returns empty dict if file is missing."""
     _migrate_old_config()
-    try:
-        with open(CONFIG_PATH, 'r') as f:
-            config = json.load(f)
-    except FileNotFoundError:
-        return {}
-    except json.JSONDecodeError as e:
-        log.warning("Config file is corrupt (%s) — resetting to defaults: %s", CONFIG_PATH, e)
-        return {}
-    except OSError as e:
-        log.error("Failed to read config file (%s): %s", CONFIG_PATH, e)
-        return {}
+    with _config_lock:
+        try:
+            with open(CONFIG_PATH, 'r') as f:
+                config = json.load(f)
+        except FileNotFoundError:
+            return {}
+        except json.JSONDecodeError as e:
+            log.warning("Config file is corrupt (%s) — resetting to defaults: %s", CONFIG_PATH, e)
+            return {}
+        except OSError as e:
+            log.error("Failed to read config file (%s): %s", CONFIG_PATH, e)
+            return {}
     if _migrate_device_keys(config):
         save_config(config)
     return config
 
 
 def save_config(config: dict):
-    """Save user config to disk (fsync'd for durability across shutdowns)."""
+    """Save user config to disk atomically (write-to-temp + rename).
+
+    Prevents corruption when the LED cycle timer and GUI save concurrently.
+    """
     os.makedirs(CONFIG_DIR, exist_ok=True)
-    with open(CONFIG_PATH, 'w') as f:
-        json.dump(config, f, indent=2)
-        f.flush()
-        os.fsync(f.fileno())
+    with _config_lock:
+        fd, tmp_path = tempfile.mkstemp(dir=CONFIG_DIR, suffix='.tmp')
+        try:
+            with os.fdopen(fd, 'w') as f:
+                json.dump(config, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, CONFIG_PATH)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
 
 # =========================================================================

--- a/src/trcc/conf.py
+++ b/src/trcc/conf.py
@@ -345,21 +345,6 @@ class Settings:
         save_config(config)
 
     @staticmethod
-    def _get_saved_gpu_pci_slot() -> str | None:
-        """Get saved GPU PCI slot preference. Returns None if not set."""
-        return load_config().get('gpu_pci_slot')
-
-    @staticmethod
-    def _save_gpu_pci_slot(pci_slot: str | None):
-        """Persist GPU PCI slot preference to config."""
-        config = load_config()
-        if pci_slot is None:
-            config.pop('gpu_pci_slot', None)
-        else:
-            config['gpu_pci_slot'] = pci_slot
-        save_config(config)
-
-    @staticmethod
     def _get_saved_gpu_slots() -> dict[str, str]:
         """Get GPU slot assignments. Returns dict like {'top': '0000:0f:00.0'}."""
         return load_config().get('gpu_slots', {})
@@ -626,11 +611,6 @@ class Settings:
         """Set metrics refresh interval in seconds and persist."""
         self.refresh_interval = interval
         Settings._save_refresh_interval(interval)
-
-    @staticmethod
-    def set_gpu(pci_slot: str | None) -> None:
-        """Set preferred GPU by PCI slot (e.g. '0000:0f:00.0') and persist."""
-        Settings._save_gpu_pci_slot(pci_slot)
 
     @staticmethod
     def set_gpu_indicator_color(color: str) -> None:

--- a/src/trcc/conf.py
+++ b/src/trcc/conf.py
@@ -328,6 +328,21 @@ class Settings:
         save_config(config)
 
     @staticmethod
+    def _get_saved_gpu_pci_slot() -> str | None:
+        """Get saved GPU PCI slot preference. Returns None if not set."""
+        return load_config().get('gpu_pci_slot')
+
+    @staticmethod
+    def _save_gpu_pci_slot(pci_slot: str | None):
+        """Persist GPU PCI slot preference to config."""
+        config = load_config()
+        if pci_slot is None:
+            config.pop('gpu_pci_slot', None)
+        else:
+            config['gpu_pci_slot'] = pci_slot
+        save_config(config)
+
+    @staticmethod
     def _get_saved_refresh_interval() -> int:
         """Get saved metrics refresh interval in seconds. Defaults to 1."""
         return int(load_config().get('refresh_interval', 1))
@@ -555,6 +570,20 @@ class Settings:
         """Set metrics refresh interval in seconds and persist."""
         self.refresh_interval = interval
         Settings._save_refresh_interval(interval)
+
+    @staticmethod
+    def set_gpu(pci_slot: str | None) -> None:
+        """Set preferred GPU by PCI slot (e.g. '0000:0f:00.0') and persist.
+
+        Invalidates the sensor default map cache so the new GPU takes effect.
+        """
+        Settings._save_gpu_pci_slot(pci_slot)
+        # Invalidate cached sensor mapping so next read uses the new GPU
+        try:
+            from trcc.adapters.system.linux.sensors import SensorEnumerator
+            SensorEnumerator._default_map = None
+        except ImportError:
+            pass
 
     @property
     def lang(self) -> str:

--- a/src/trcc/conf.py
+++ b/src/trcc/conf.py
@@ -343,6 +343,45 @@ class Settings:
         save_config(config)
 
     @staticmethod
+    def _get_saved_gpu_slots() -> dict[str, str]:
+        """Get GPU slot assignments. Returns dict like {'top': '0000:0f:00.0'}."""
+        return load_config().get('gpu_slots', {})
+
+    @staticmethod
+    def _save_gpu_slots(slots: dict[str, str]):
+        """Persist GPU slot assignments."""
+        config = load_config()
+        if not slots:
+            config.pop('gpu_slots', None)
+        else:
+            config['gpu_slots'] = slots
+        save_config(config)
+
+    @staticmethod
+    def _get_saved_gpu_cycle_seconds() -> int:
+        """Get GPU cycle interval in seconds. Defaults to 5."""
+        return int(load_config().get('gpu_cycle_seconds', 5))
+
+    @staticmethod
+    def _save_gpu_cycle_seconds(seconds: int):
+        """Persist GPU cycle interval."""
+        config = load_config()
+        config['gpu_cycle_seconds'] = seconds
+        save_config(config)
+
+    @staticmethod
+    def _get_saved_gpu_indicator_color() -> str:
+        """Get GPU indicator LED color as hex. Defaults to pure blue."""
+        return load_config().get('gpu_indicator_color', '#0000FF')
+
+    @staticmethod
+    def _save_gpu_indicator_color(color: str):
+        """Persist GPU indicator LED color."""
+        config = load_config()
+        config['gpu_indicator_color'] = color
+        save_config(config)
+
+    @staticmethod
     def _get_saved_refresh_interval() -> int:
         """Get saved metrics refresh interval in seconds. Defaults to 1."""
         return int(load_config().get('refresh_interval', 1))
@@ -575,6 +614,12 @@ class Settings:
     def set_gpu(pci_slot: str | None) -> None:
         """Set preferred GPU by PCI slot (e.g. '0000:0f:00.0') and persist."""
         Settings._save_gpu_pci_slot(pci_slot)
+
+    @staticmethod
+    def set_gpu_slots(slots: dict[str, str], cycle_seconds: int = 5) -> None:
+        """Set GPU slot assignments (multi-GPU cycle mode) and persist."""
+        Settings._save_gpu_slots(slots)
+        Settings._save_gpu_cycle_seconds(cycle_seconds)
 
     @property
     def lang(self) -> str:

--- a/src/trcc/core/led_segment.py
+++ b/src/trcc/core/led_segment.py
@@ -293,6 +293,11 @@ class PA120Display(SegmentDisplay):
         (73, 74, 75, 76, 77, 78, 79),
     )
     GPU_USE_PARTIAL = (82, 83)
+    GPU_INDICATOR_LEDS: dict[str, int] = {
+        'top': 45,     # segment A on GPU_TEMP_DIGITS[0]
+        'middle': 51,  # segment G on GPU_TEMP_DIGITS[0]
+        'bottom': 48,  # segment D on GPU_TEMP_DIGITS[0]
+    }
     ZONE_LEDS: Tuple[Tuple[int, ...], ...] = (
         (CPU1, CPU2, SSD, HSD) + tuple(range(10, 31)),
         (BFB,) + tuple(range(31, 45)) + (80, 81),
@@ -326,6 +331,10 @@ class PA120Display(SegmentDisplay):
         self._encode_2digit_partial(
             int(getattr(metrics, 'gpu_usage', 0)),
             self.GPU_USE_DIGITS, self.GPU_USE_PARTIAL, mask)
+        # GPU indicator: light horizontal segment on leftmost temp digit
+        gpu_indicator_slot = kw.get('gpu_indicator_slot')
+        if gpu_indicator_slot and gpu_indicator_slot in self.GPU_INDICATOR_LEDS:
+            mask[self.GPU_INDICATOR_LEDS[gpu_indicator_slot]] = True
         return mask
 
 

--- a/src/trcc/services/led.py
+++ b/src/trcc/services/led.py
@@ -396,6 +396,11 @@ class LEDService:
                 SensorEnumerator._default_map = None
             except ImportError:
                 pass
+            try:
+                from trcc.services.system import get_instance
+                get_instance()._defaults = None
+            except (ImportError, RuntimeError):
+                pass
 
     def _update_segment_mask(self) -> None:
         """Recompute segment mask from current metrics + rotation phase.

--- a/src/trcc/services/led.py
+++ b/src/trcc/services/led.py
@@ -422,15 +422,15 @@ class LEDService:
             return
         try:
             from trcc.services.system import get_instance
-            enumerator = get_instance()._enumerator
+            svc = get_instance()
             for slot in self._gpu_slot_order:
                 pci = self._gpu_slots[slot]
-                self._gpu_slot_mappings[slot] = enumerator.gpu_mapping_for_pci(pci)
+                self._gpu_slot_mappings[slot] = svc.gpu_mapping_for_pci(pci)
         except (ImportError, RuntimeError):
             pass
 
     def _swap_gpu_mapping(self) -> None:
-        """Patch SystemService._defaults with pre-built GPU sensor IDs.
+        """Reroute GPU sensor IDs via SystemService public API.
 
         All GPU sensor data is already in the read cache — this just
         switches which sensor IDs the metric keys point to.  Instant,
@@ -442,9 +442,7 @@ class LEDService:
             return
         try:
             from trcc.services.system import get_instance
-            svc = get_instance()
-            if svc._defaults is not None:
-                svc._defaults.update(mapping)
+            get_instance().update_gpu_defaults(mapping)
         except (ImportError, RuntimeError):
             pass
 

--- a/src/trcc/services/led.py
+++ b/src/trcc/services/led.py
@@ -72,6 +72,14 @@ class LEDService:
         self._device_key: Optional[str] = None
         self._led_style: int = 1
 
+        # GPU cycle state (PA120 multi-GPU slot rotation)
+        self._gpu_slots: dict[str, str] = {}
+        self._gpu_slot_order: list[str] = []
+        self._gpu_active_slot: str = ''
+        self._gpu_cycle_seconds: int = 5
+        self._gpu_cycle_ticks: int = 0
+        self._gpu_indicator_color: tuple[int, int, int] = (0, 0, 255)
+
     # ── Style resolution (static) ───────────────────────────────────
 
     @staticmethod
@@ -275,6 +283,9 @@ class LEDService:
             self._seg_tick_count = 0
             self._update_segment_mask()
 
+        if self._seg_display and hasattr(self._seg_display, 'GPU_INDICATOR_LEDS'):
+            self._init_gpu_cycle()
+
     # ── Effect engine ───────────────────────────────────────────────
 
     def tick(self) -> List[Tuple[int, int, int]]:
@@ -307,8 +318,14 @@ class LEDService:
             if zone_map:
                 # Styles 2/7 (PA120/LF10): physical zones with per-zone
                 # color/mode — each zone colors its own mapped LED indices.
-                return self._tick_multi_zone(
+                self._advance_gpu_cycle()
+                colors = self._tick_multi_zone(
                     zone_map, self._seg_display.zone_metric_sources)
+                if self._gpu_active_slot and hasattr(self._seg_display, 'GPU_INDICATOR_LEDS'):
+                    indicator_led = self._seg_display.GPU_INDICATOR_LEDS.get(self._gpu_active_slot)
+                    if indicator_led is not None and indicator_led < len(colors):
+                        colors[indicator_led] = self._gpu_indicator_color
+                return colors
             # Non-2/7 styles: C# uses global rgbR1/G1/B1 and myLedMode.
             # Zones only drive segment display data rotation (CPU/GPU),
             # not LED color. Fall through to global tick below.
@@ -340,6 +357,46 @@ class LEDService:
                 return candidate
         return current
 
+    def _init_gpu_cycle(self) -> None:
+        """Load GPU cycle config. Called on configure_for_style for PA120."""
+        from trcc.conf import load_config
+        config = load_config()
+        self._gpu_slots = config.get('gpu_slots', {})
+        slot_order = ['top', 'middle', 'bottom']
+        self._gpu_slot_order = [s for s in slot_order if s in self._gpu_slots]
+        self._gpu_active_slot = config.get('gpu_active_slot', '')
+        if self._gpu_active_slot not in self._gpu_slot_order and self._gpu_slot_order:
+            self._gpu_active_slot = self._gpu_slot_order[0]
+        self._gpu_cycle_seconds = config.get('gpu_cycle_seconds', 5)
+        self._gpu_cycle_ticks = 0
+        hex_color = config.get('gpu_indicator_color', '#0000FF')
+        try:
+            h = hex_color.lstrip('#')
+            self._gpu_indicator_color = (int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+        except (ValueError, IndexError):
+            self._gpu_indicator_color = (0, 0, 255)
+
+    def _advance_gpu_cycle(self) -> None:
+        """Advance cycle timer. Rotate to next slot when timer fires."""
+        if len(self._gpu_slot_order) < 2:
+            return
+        self._gpu_cycle_ticks += 1
+        ticks_needed = max(1, int(self._gpu_cycle_seconds / 0.15))
+        if self._gpu_cycle_ticks >= ticks_needed:
+            self._gpu_cycle_ticks = 0
+            current_idx = self._gpu_slot_order.index(self._gpu_active_slot)
+            next_idx = (current_idx + 1) % len(self._gpu_slot_order)
+            self._gpu_active_slot = self._gpu_slot_order[next_idx]
+            from trcc.conf import load_config, save_config
+            config = load_config()
+            config['gpu_active_slot'] = self._gpu_active_slot
+            save_config(config)
+            try:
+                from trcc.adapters.system.linux.sensors import SensorEnumerator
+                SensorEnumerator._default_map = None
+            except ImportError:
+                pass
+
     def _update_segment_mask(self) -> None:
         """Recompute segment mask from current metrics + rotation phase.
 
@@ -357,6 +414,7 @@ class LEDService:
             week_sunday=self.state.is_week_sunday,
             sub_style=self.state.sub_style,
             memory_ratio=self.state.memory_ratio,
+            gpu_indicator_slot=self._gpu_active_slot if self._gpu_slots else None,
         )
 
     # ── Display-ready colors ────────────────────────────────────────

--- a/src/trcc/services/led.py
+++ b/src/trcc/services/led.py
@@ -7,6 +7,7 @@ LEDDevice (core/led_device.py) delegates to this service.
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from typing import Any, List, Optional, Tuple
 
@@ -377,17 +378,9 @@ class LEDService:
             self._gpu_indicator_color = (int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
         except (ValueError, IndexError):
             self._gpu_indicator_color = (0, 0, 255)
-        # Pre-build sensor mappings per slot for instant switching
+        # Pre-built sensor mappings per slot — populated on first tick
+        # (too early to enumerate sensors during connect/handshake phase)
         self._gpu_slot_mappings = {}
-        if len(self._gpu_slot_order) >= 2:
-            try:
-                from trcc.adapters.system.linux.sensors import SensorEnumerator
-                enumerator = SensorEnumerator()
-                for slot in self._gpu_slot_order:
-                    pci = self._gpu_slots[slot]
-                    self._gpu_slot_mappings[slot] = enumerator.gpu_mapping_for_pci(pci)
-            except ImportError:
-                pass
 
     def _advance_gpu_cycle(self) -> None:
         """Advance cycle timer. Rotate to next slot when timer fires."""
@@ -399,12 +392,42 @@ class LEDService:
             current_idx = self._gpu_slot_order.index(self._gpu_active_slot)
             next_idx = (current_idx + 1) % len(self._gpu_slot_order)
             self._gpu_active_slot = self._gpu_slot_order[next_idx]
-            from trcc.conf import load_config, save_config
-            config = load_config()
-            config['gpu_active_slot'] = self._gpu_active_slot
-            save_config(config)
             self._swap_gpu_mapping()
+            # Re-read metrics immediately so display shows new GPU's data
+            try:
+                from trcc.services.system import get_instance
+                fresh = get_instance().all_metrics()
+                self._metrics = fresh
+                self._engine.metrics = fresh
+            except (ImportError, RuntimeError):
+                pass
             self._update_segment_mask()
+            # Persist active slot in background — not worth blocking render
+            slot = self._gpu_active_slot
+            threading.Thread(
+                target=self._save_active_slot, args=(slot,), daemon=True,
+            ).start()
+
+    @staticmethod
+    def _save_active_slot(slot: str) -> None:
+        """Persist gpu_active_slot to config (runs in background thread)."""
+        from trcc.conf import load_config, save_config
+        config = load_config()
+        config['gpu_active_slot'] = slot
+        save_config(config)
+
+    def _ensure_gpu_slot_mappings(self) -> None:
+        """Lazily build per-slot sensor mappings on first call."""
+        if self._gpu_slot_mappings:
+            return
+        try:
+            from trcc.services.system import get_instance
+            enumerator = get_instance()._enumerator
+            for slot in self._gpu_slot_order:
+                pci = self._gpu_slots[slot]
+                self._gpu_slot_mappings[slot] = enumerator.gpu_mapping_for_pci(pci)
+        except (ImportError, RuntimeError):
+            pass
 
     def _swap_gpu_mapping(self) -> None:
         """Patch SystemService._defaults with pre-built GPU sensor IDs.
@@ -413,6 +436,7 @@ class LEDService:
         switches which sensor IDs the metric keys point to.  Instant,
         no re-enumeration or cache invalidation needed.
         """
+        self._ensure_gpu_slot_mappings()
         mapping = self._gpu_slot_mappings.get(self._gpu_active_slot)
         if not mapping:
             return

--- a/src/trcc/services/led.py
+++ b/src/trcc/services/led.py
@@ -7,6 +7,7 @@ LEDDevice (core/led_device.py) delegates to this service.
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any, List, Optional, Tuple
 
 from ..core.models import (
@@ -77,7 +78,7 @@ class LEDService:
         self._gpu_slot_order: list[str] = []
         self._gpu_active_slot: str = ''
         self._gpu_cycle_seconds: int = 5
-        self._gpu_cycle_ticks: int = 0
+        self._gpu_cycle_last: float = 0.0
         self._gpu_indicator_color: tuple[int, int, int] = (0, 0, 255)
 
     # ── Style resolution (static) ───────────────────────────────────
@@ -368,7 +369,7 @@ class LEDService:
         if self._gpu_active_slot not in self._gpu_slot_order and self._gpu_slot_order:
             self._gpu_active_slot = self._gpu_slot_order[0]
         self._gpu_cycle_seconds = config.get('gpu_cycle_seconds', 5)
-        self._gpu_cycle_ticks = 0
+        self._gpu_cycle_last = time.monotonic()
         hex_color = config.get('gpu_indicator_color', '#0000FF')
         try:
             h = hex_color.lstrip('#')
@@ -380,10 +381,9 @@ class LEDService:
         """Advance cycle timer. Rotate to next slot when timer fires."""
         if len(self._gpu_slot_order) < 2:
             return
-        self._gpu_cycle_ticks += 1
-        ticks_needed = max(1, int(self._gpu_cycle_seconds / 0.15))
-        if self._gpu_cycle_ticks >= ticks_needed:
-            self._gpu_cycle_ticks = 0
+        now = time.monotonic()
+        if (now - self._gpu_cycle_last) >= self._gpu_cycle_seconds:
+            self._gpu_cycle_last = now
             current_idx = self._gpu_slot_order.index(self._gpu_active_slot)
             next_idx = (current_idx + 1) % len(self._gpu_slot_order)
             self._gpu_active_slot = self._gpu_slot_order[next_idx]
@@ -401,6 +401,7 @@ class LEDService:
                 get_instance()._defaults = None
             except (ImportError, RuntimeError):
                 pass
+            self._update_segment_mask()
 
     def _update_segment_mask(self) -> None:
         """Recompute segment mask from current metrics + rotation phase.

--- a/src/trcc/services/led.py
+++ b/src/trcc/services/led.py
@@ -80,6 +80,7 @@ class LEDService:
         self._gpu_cycle_seconds: int = 5
         self._gpu_cycle_last: float = 0.0
         self._gpu_indicator_color: tuple[int, int, int] = (0, 0, 255)
+        self._gpu_slot_mappings: dict[str, dict[str, str]] = {}
 
     # ── Style resolution (static) ───────────────────────────────────
 
@@ -376,6 +377,17 @@ class LEDService:
             self._gpu_indicator_color = (int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
         except (ValueError, IndexError):
             self._gpu_indicator_color = (0, 0, 255)
+        # Pre-build sensor mappings per slot for instant switching
+        self._gpu_slot_mappings = {}
+        if len(self._gpu_slot_order) >= 2:
+            try:
+                from trcc.adapters.system.linux.sensors import SensorEnumerator
+                enumerator = SensorEnumerator()
+                for slot in self._gpu_slot_order:
+                    pci = self._gpu_slots[slot]
+                    self._gpu_slot_mappings[slot] = enumerator.gpu_mapping_for_pci(pci)
+            except ImportError:
+                pass
 
     def _advance_gpu_cycle(self) -> None:
         """Advance cycle timer. Rotate to next slot when timer fires."""
@@ -391,17 +403,26 @@ class LEDService:
             config = load_config()
             config['gpu_active_slot'] = self._gpu_active_slot
             save_config(config)
-            try:
-                from trcc.adapters.system.linux.sensors import SensorEnumerator
-                SensorEnumerator._default_map = None
-            except ImportError:
-                pass
-            try:
-                from trcc.services.system import get_instance
-                get_instance()._defaults = None
-            except (ImportError, RuntimeError):
-                pass
+            self._swap_gpu_mapping()
             self._update_segment_mask()
+
+    def _swap_gpu_mapping(self) -> None:
+        """Patch SystemService._defaults with pre-built GPU sensor IDs.
+
+        All GPU sensor data is already in the read cache — this just
+        switches which sensor IDs the metric keys point to.  Instant,
+        no re-enumeration or cache invalidation needed.
+        """
+        mapping = self._gpu_slot_mappings.get(self._gpu_active_slot)
+        if not mapping:
+            return
+        try:
+            from trcc.services.system import get_instance
+            svc = get_instance()
+            if svc._defaults is not None:
+                svc._defaults.update(mapping)
+        except (ImportError, RuntimeError):
+            pass
 
     def _update_segment_mask(self) -> None:
         """Recompute segment mask from current metrics + rotation phase.

--- a/src/trcc/services/led.py
+++ b/src/trcc/services/led.py
@@ -396,7 +396,7 @@ class LEDService:
             # Re-read metrics immediately so display shows new GPU's data
             try:
                 from trcc.services.system import get_instance
-                fresh = get_instance().all_metrics()
+                fresh = get_instance().all_metrics
                 self._metrics = fresh
                 self._engine.metrics = fresh
             except (ImportError, RuntimeError):

--- a/src/trcc/services/system.py
+++ b/src/trcc/services/system.py
@@ -126,6 +126,26 @@ class SystemService:
             return self._enumerator.read_one(sensor_id)
         return None
 
+    # ── GPU slot support (used by LEDService for instant GPU switching) ──
+
+    def gpu_mapping_for_pci(self, pci_slot: str) -> dict[str, str]:
+        """Build gpu_temp/usage/clock/power sensor IDs for a PCI slot.
+
+        Delegates to the enumerator. Used by LEDService to pre-build
+        per-slot sensor mappings at init.
+        """
+        self._ensure_discovered()
+        return self._enumerator.gpu_mapping_for_pci(pci_slot)
+
+    def update_gpu_defaults(self, mapping: dict[str, str]) -> None:
+        """Patch the cached defaults with GPU sensor IDs for a specific slot.
+
+        Called by LEDService on cycle switch to reroute gpu_temp/usage/etc.
+        to the newly active GPU's sensors without full re-enumeration.
+        """
+        defaults = self._ensure_defaults()
+        defaults.update(mapping)
+
     # ── Metric properties ─────────────────────────────────────────────
 
     @property

--- a/tests/adapters/system/linux/test_gpu_cycle_mapping.py
+++ b/tests/adapters/system/linux/test_gpu_cycle_mapping.py
@@ -1,0 +1,35 @@
+from unittest.mock import patch
+
+from trcc.adapters.system.linux.sensors import SensorEnumerator
+
+
+def test_map_defaults_uses_active_gpu_slot():
+    """When gpu_slots config exists, map_defaults uses the active slot's GPU."""
+    config = {
+        'gpu_slots': {'top': '0000:0f:00.0', 'bottom': '0000:06:00.0'},
+        'gpu_active_slot': 'top',
+    }
+    fake_gpus = [
+        {'pci_slot': '0000:0f:00.0', 'vendor': '1002', 'name': 'RX 7900 XTX',
+         'driver_key': 'amdgpu.1', 'drm_card': 'card1'},
+    ]
+    with patch("trcc.conf.load_config", return_value=config), \
+         patch("trcc.adapters.system.linux.sensors.detect_gpus", return_value=fake_gpus):
+        enum = SensorEnumerator()
+        SensorEnumerator._default_map = None
+        defaults = enum.map_defaults()
+        assert isinstance(defaults, dict)
+
+def test_map_defaults_falls_back_to_gpu_pci_slot():
+    """When no gpu_slots, falls back to legacy gpu_pci_slot."""
+    config = {'gpu_pci_slot': '0000:0f:00.0'}
+    fake_gpus = [
+        {'pci_slot': '0000:0f:00.0', 'vendor': '1002', 'name': 'RX 7900 XTX',
+         'driver_key': 'amdgpu.1', 'drm_card': 'card1'},
+    ]
+    with patch("trcc.conf.load_config", return_value=config), \
+         patch("trcc.adapters.system.linux.sensors.detect_gpus", return_value=fake_gpus):
+        enum = SensorEnumerator()
+        SensorEnumerator._default_map = None
+        defaults = enum.map_defaults()
+        assert isinstance(defaults, dict)

--- a/tests/adapters/system/linux/test_gpu_cycle_mapping.py
+++ b/tests/adapters/system/linux/test_gpu_cycle_mapping.py
@@ -3,32 +3,36 @@ from unittest.mock import patch
 from trcc.adapters.system.linux.sensors import SensorEnumerator
 
 
-def test_map_defaults_uses_active_gpu_slot():
-    """When gpu_slots config exists, map_defaults uses the active slot's GPU."""
-    config = {
-        'gpu_slots': {'top': '0000:0f:00.0', 'bottom': '0000:06:00.0'},
-        'gpu_active_slot': 'top',
-    }
+def test_gpu_mapping_for_pci_amd():
+    """gpu_mapping_for_pci returns sensor IDs for an AMD GPU by PCI slot."""
     fake_gpus = [
         {'pci_slot': '0000:0f:00.0', 'vendor': '1002', 'name': 'RX 7900 XTX',
-         'driver_key': 'amdgpu.1', 'drm_card': 'card1'},
+         'driver_key': 'amdgpu.1', 'drm_card': 'card2'},
+        {'pci_slot': '0000:06:00.0', 'vendor': '1002', 'name': 'RX 5700 XT',
+         'driver_key': 'amdgpu', 'drm_card': 'card1'},
     ]
-    with patch("trcc.conf.load_config", return_value=config), \
-         patch("trcc.adapters.system.linux.sensors.detect_gpus", return_value=fake_gpus):
+    with patch("trcc.adapters.system.linux.sensors.detect_gpus", return_value=fake_gpus):
         enum = SensorEnumerator()
-        SensorEnumerator._default_map = None
-        defaults = enum.map_defaults()
-        assert isinstance(defaults, dict)
+        mapping = enum.gpu_mapping_for_pci('0000:06:00.0')
+        assert 'gpu_temp' in mapping
+        assert 'gpu_usage' in mapping
+        assert 'gpu_clock' in mapping
+        assert 'gpu_power' in mapping
 
-def test_map_defaults_falls_back_to_gpu_pci_slot():
-    """When no gpu_slots, falls back to legacy gpu_pci_slot."""
-    config = {'gpu_pci_slot': '0000:0f:00.0'}
-    fake_gpus = [
-        {'pci_slot': '0000:0f:00.0', 'vendor': '1002', 'name': 'RX 7900 XTX',
-         'driver_key': 'amdgpu.1', 'drm_card': 'card1'},
-    ]
-    with patch("trcc.conf.load_config", return_value=config), \
-         patch("trcc.adapters.system.linux.sensors.detect_gpus", return_value=fake_gpus):
+
+def test_gpu_mapping_for_pci_unknown():
+    """gpu_mapping_for_pci returns empty strings for unknown PCI slot."""
+    with patch("trcc.adapters.system.linux.sensors.detect_gpus", return_value=[]):
+        enum = SensorEnumerator()
+        mapping = enum.gpu_mapping_for_pci('0000:99:00.0')
+        assert mapping == {'gpu_temp': '', 'gpu_usage': '', 'gpu_clock': '', 'gpu_power': ''}
+
+
+def test_map_defaults_uses_best_gpu():
+    """map_defaults uses _best_gpu() — slot routing is handled by LED swap."""
+    with patch.object(SensorEnumerator, '_best_gpu',
+                      return_value={'vendor': 'amd', 'hwmon_driver': 'amdgpu',
+                                    'drm_card': 'card1', 'nvidia_idx': None}):
         enum = SensorEnumerator()
         SensorEnumerator._default_map = None
         defaults = enum.map_defaults()

--- a/tests/cli/test_set_gpu.py
+++ b/tests/cli/test_set_gpu.py
@@ -2,20 +2,15 @@
 from unittest.mock import patch, MagicMock
 
 
-def test_set_gpu_single_gpu_no_slots(monkeypatch):
-    """Single GPU: sets gpu pci slot, no slot assignment."""
+def test_set_gpu_single_gpu_exits_early(monkeypatch):
+    """Single GPU: informs user and exits without slot assignment."""
     fake_gpus = [{'pci_slot': '0000:0f:00.0', 'vendor': '1002', 'name': 'RX 7900 XTX',
                   'driver_key': 'amdgpu', 'drm_card': 'card1'}]
     monkeypatch.setattr("trcc.core.platform.LINUX", True)
-    # Patch at source so lazy imports pick up the mocks
-    with patch("trcc.adapters.system.linux.sensors.detect_gpus", return_value=fake_gpus), \
-         patch("trcc.conf.Settings") as mock_settings, \
-         patch("trcc.adapters.system.linux.sensors.SensorEnumerator") as mock_enum:
+    with patch("trcc.adapters.system.linux.sensors.detect_gpus", return_value=fake_gpus):
         from trcc.cli._system import set_gpu
         result = set_gpu()
     assert result == 0
-    mock_settings.set_gpu.assert_called_once_with('0000:0f:00.0')
-    mock_settings.set_gpu_slots.assert_not_called()
 
 
 def test_set_gpu_multi_assigns_slots(monkeypatch):
@@ -30,9 +25,9 @@ def test_set_gpu_multi_assigns_slots(monkeypatch):
     monkeypatch.setattr("trcc.core.platform.LINUX", True)
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
     with patch("trcc.adapters.system.linux.sensors.detect_gpus", return_value=fake_gpus), \
-         patch("trcc.conf.Settings") as mock_settings, \
-         patch("trcc.adapters.system.linux.sensors.SensorEnumerator"):
+         patch("trcc.conf.Settings") as mock_settings:
         mock_settings._get_saved_gpu_slots.return_value = {}
+        mock_settings._get_saved_gpu_indicator_color.return_value = '#0000FF'
         from trcc.cli._system import set_gpu
         result = set_gpu()
     assert result == 0
@@ -61,8 +56,7 @@ def test_set_gpu_no_slots_assigned(monkeypatch):
     monkeypatch.setattr("trcc.core.platform.LINUX", True)
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
     with patch("trcc.adapters.system.linux.sensors.detect_gpus", return_value=fake_gpus), \
-         patch("trcc.conf.Settings") as mock_settings, \
-         patch("trcc.adapters.system.linux.sensors.SensorEnumerator"):
+         patch("trcc.conf.Settings") as mock_settings:
         mock_settings._get_saved_gpu_slots.return_value = {}
         from trcc.cli._system import set_gpu
         result = set_gpu()

--- a/tests/cli/test_set_gpu.py
+++ b/tests/cli/test_set_gpu.py
@@ -21,7 +21,7 @@ def test_set_gpu_multi_assigns_slots(monkeypatch):
         {'pci_slot': '0000:0f:00.0', 'vendor': '1002', 'name': 'RX 7900 XTX',
          'driver_key': 'amdgpu.1', 'drm_card': 'card1'},
     ]
-    inputs = iter(["2", "", "1", ""])
+    inputs = iter(["2", "", "1", "", ""])
     monkeypatch.setattr("trcc.core.platform.LINUX", True)
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
     with patch("trcc.adapters.system.linux.sensors.detect_gpus", return_value=fake_gpus), \

--- a/tests/cli/test_set_gpu.py
+++ b/tests/cli/test_set_gpu.py
@@ -1,17 +1,17 @@
 # tests/cli/test_set_gpu.py
-from unittest.mock import patch
-
-from trcc.cli._system import set_gpu
+from unittest.mock import patch, MagicMock
 
 
 def test_set_gpu_single_gpu_no_slots(monkeypatch):
     """Single GPU: sets gpu pci slot, no slot assignment."""
     fake_gpus = [{'pci_slot': '0000:0f:00.0', 'vendor': '1002', 'name': 'RX 7900 XTX',
                   'driver_key': 'amdgpu', 'drm_card': 'card1'}]
-    monkeypatch.setattr("trcc.cli._system.LINUX", True)
-    with patch("trcc.cli._system.detect_gpus", return_value=fake_gpus), \
-         patch("trcc.cli._system.Settings") as mock_settings, \
-         patch("trcc.cli._system.SensorEnumerator"):
+    monkeypatch.setattr("trcc.core.platform.LINUX", True)
+    # Patch at source so lazy imports pick up the mocks
+    with patch("trcc.adapters.system.linux.sensors.detect_gpus", return_value=fake_gpus), \
+         patch("trcc.conf.Settings") as mock_settings, \
+         patch("trcc.adapters.system.linux.sensors.SensorEnumerator") as mock_enum:
+        from trcc.cli._system import set_gpu
         result = set_gpu()
     assert result == 0
     mock_settings.set_gpu.assert_called_once_with('0000:0f:00.0')
@@ -26,14 +26,14 @@ def test_set_gpu_multi_assigns_slots(monkeypatch):
         {'pci_slot': '0000:0f:00.0', 'vendor': '1002', 'name': 'RX 7900 XTX',
          'driver_key': 'amdgpu.1', 'drm_card': 'card1'},
     ]
-    # User picks: GPU 2 for top, skip middle, GPU 1 for bottom, default frequency
     inputs = iter(["2", "", "1", ""])
-    monkeypatch.setattr("trcc.cli._system.LINUX", True)
+    monkeypatch.setattr("trcc.core.platform.LINUX", True)
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
-    with patch("trcc.cli._system.detect_gpus", return_value=fake_gpus), \
-         patch("trcc.cli._system.Settings") as mock_settings, \
-         patch("trcc.cli._system.SensorEnumerator"):
+    with patch("trcc.adapters.system.linux.sensors.detect_gpus", return_value=fake_gpus), \
+         patch("trcc.conf.Settings") as mock_settings, \
+         patch("trcc.adapters.system.linux.sensors.SensorEnumerator"):
         mock_settings._get_saved_gpu_slots.return_value = {}
+        from trcc.cli._system import set_gpu
         result = set_gpu()
     assert result == 0
     mock_settings.set_gpu_slots.assert_called_once_with(
@@ -42,8 +42,9 @@ def test_set_gpu_multi_assigns_slots(monkeypatch):
 
 def test_set_gpu_no_gpus(monkeypatch):
     """No GPUs detected returns 1."""
-    monkeypatch.setattr("trcc.cli._system.LINUX", True)
-    with patch("trcc.cli._system.detect_gpus", return_value=[]):
+    monkeypatch.setattr("trcc.core.platform.LINUX", True)
+    with patch("trcc.adapters.system.linux.sensors.detect_gpus", return_value=[]):
+        from trcc.cli._system import set_gpu
         result = set_gpu()
     assert result == 1
 
@@ -56,12 +57,13 @@ def test_set_gpu_no_slots_assigned(monkeypatch):
         {'pci_slot': '0000:0f:00.0', 'vendor': '1002', 'name': 'RX 7900 XTX',
          'driver_key': 'amdgpu.1', 'drm_card': 'card1'},
     ]
-    inputs = iter(["", "", "", ""])  # skip all slots
-    monkeypatch.setattr("trcc.cli._system.LINUX", True)
+    inputs = iter(["", "", "", ""])
+    monkeypatch.setattr("trcc.core.platform.LINUX", True)
     monkeypatch.setattr("builtins.input", lambda _: next(inputs))
-    with patch("trcc.cli._system.detect_gpus", return_value=fake_gpus), \
-         patch("trcc.cli._system.Settings") as mock_settings, \
-         patch("trcc.cli._system.SensorEnumerator"):
+    with patch("trcc.adapters.system.linux.sensors.detect_gpus", return_value=fake_gpus), \
+         patch("trcc.conf.Settings") as mock_settings, \
+         patch("trcc.adapters.system.linux.sensors.SensorEnumerator"):
         mock_settings._get_saved_gpu_slots.return_value = {}
+        from trcc.cli._system import set_gpu
         result = set_gpu()
     assert result == 1

--- a/tests/cli/test_set_gpu.py
+++ b/tests/cli/test_set_gpu.py
@@ -1,0 +1,67 @@
+# tests/cli/test_set_gpu.py
+from unittest.mock import patch
+
+from trcc.cli._system import set_gpu
+
+
+def test_set_gpu_single_gpu_no_slots(monkeypatch):
+    """Single GPU: sets gpu pci slot, no slot assignment."""
+    fake_gpus = [{'pci_slot': '0000:0f:00.0', 'vendor': '1002', 'name': 'RX 7900 XTX',
+                  'driver_key': 'amdgpu', 'drm_card': 'card1'}]
+    monkeypatch.setattr("trcc.cli._system.LINUX", True)
+    with patch("trcc.cli._system.detect_gpus", return_value=fake_gpus), \
+         patch("trcc.cli._system.Settings") as mock_settings, \
+         patch("trcc.cli._system.SensorEnumerator"):
+        result = set_gpu()
+    assert result == 0
+    mock_settings.set_gpu.assert_called_once_with('0000:0f:00.0')
+    mock_settings.set_gpu_slots.assert_not_called()
+
+
+def test_set_gpu_multi_assigns_slots(monkeypatch):
+    """Multi-GPU: user assigns GPUs to top and bottom slots."""
+    fake_gpus = [
+        {'pci_slot': '0000:06:00.0', 'vendor': '1002', 'name': 'RX 5700 XT',
+         'driver_key': 'amdgpu', 'drm_card': 'card0'},
+        {'pci_slot': '0000:0f:00.0', 'vendor': '1002', 'name': 'RX 7900 XTX',
+         'driver_key': 'amdgpu.1', 'drm_card': 'card1'},
+    ]
+    # User picks: GPU 2 for top, skip middle, GPU 1 for bottom, default frequency
+    inputs = iter(["2", "", "1", ""])
+    monkeypatch.setattr("trcc.cli._system.LINUX", True)
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    with patch("trcc.cli._system.detect_gpus", return_value=fake_gpus), \
+         patch("trcc.cli._system.Settings") as mock_settings, \
+         patch("trcc.cli._system.SensorEnumerator"):
+        mock_settings._get_saved_gpu_slots.return_value = {}
+        result = set_gpu()
+    assert result == 0
+    mock_settings.set_gpu_slots.assert_called_once_with(
+        {"top": "0000:0f:00.0", "bottom": "0000:06:00.0"}, 5)
+
+
+def test_set_gpu_no_gpus(monkeypatch):
+    """No GPUs detected returns 1."""
+    monkeypatch.setattr("trcc.cli._system.LINUX", True)
+    with patch("trcc.cli._system.detect_gpus", return_value=[]):
+        result = set_gpu()
+    assert result == 1
+
+
+def test_set_gpu_no_slots_assigned(monkeypatch):
+    """Multi-GPU but user skips all slots returns 1."""
+    fake_gpus = [
+        {'pci_slot': '0000:06:00.0', 'vendor': '1002', 'name': 'RX 5700 XT',
+         'driver_key': 'amdgpu', 'drm_card': 'card0'},
+        {'pci_slot': '0000:0f:00.0', 'vendor': '1002', 'name': 'RX 7900 XTX',
+         'driver_key': 'amdgpu.1', 'drm_card': 'card1'},
+    ]
+    inputs = iter(["", "", "", ""])  # skip all slots
+    monkeypatch.setattr("trcc.cli._system.LINUX", True)
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+    with patch("trcc.cli._system.detect_gpus", return_value=fake_gpus), \
+         patch("trcc.cli._system.Settings") as mock_settings, \
+         patch("trcc.cli._system.SensorEnumerator"):
+        mock_settings._get_saved_gpu_slots.return_value = {}
+        result = set_gpu()
+    assert result == 1

--- a/tests/core/test_led_segment.py
+++ b/tests/core/test_led_segment.py
@@ -1522,3 +1522,36 @@ class TestCrossStyleConsistency:
 
                 def compute_mask(self, metrics, phase=0, temp_unit="C", **kw):  # type: ignore[override]
                     return []
+
+
+class TestPA120GpuIndicator:
+    def test_indicator_top_slot(self):
+        """Top slot indicator lights segment A (LED 45)."""
+        d = PA120Display()
+        m = HardwareMetrics(cpu_temp=50.0, cpu_percent=30.0, gpu_temp=65.0, gpu_usage=40.0)
+        mask = d.compute_mask(m, gpu_indicator_slot="top")
+        assert mask[45] is True
+
+    def test_indicator_middle_slot(self):
+        """Middle slot indicator lights segment G (LED 51)."""
+        d = PA120Display()
+        m = HardwareMetrics(cpu_temp=50.0, cpu_percent=30.0, gpu_temp=65.0, gpu_usage=40.0)
+        mask = d.compute_mask(m, gpu_indicator_slot="middle")
+        assert mask[51] is True
+
+    def test_indicator_bottom_slot(self):
+        """Bottom slot indicator lights segment D (LED 48)."""
+        d = PA120Display()
+        m = HardwareMetrics(cpu_temp=50.0, cpu_percent=30.0, gpu_temp=65.0, gpu_usage=40.0)
+        mask = d.compute_mask(m, gpu_indicator_slot="bottom")
+        assert mask[48] is True
+
+    def test_no_indicator_when_none(self):
+        """No extra indicator LED when gpu_indicator_slot not passed."""
+        d = PA120Display()
+        # gpu_temp=15 → leftmost digit blank (leading zero suppressed), LED 45 off
+        m = HardwareMetrics(cpu_temp=50.0, cpu_percent=30.0, gpu_temp=15.0, gpu_usage=40.0)
+        mask_no_indicator = d.compute_mask(m)
+        mask_indicator = d.compute_mask(m, gpu_indicator_slot="top")
+        assert mask_no_indicator[45] is False
+        assert mask_indicator[45] is True

--- a/tests/services/test_led.py
+++ b/tests/services/test_led.py
@@ -1306,3 +1306,56 @@ class TestLEDServiceGetattr:
         """Accessing an unknown attribute raises AttributeError."""
         with pytest.raises(AttributeError):
             _ = led_svc.totally_unknown_attribute_xyz
+
+
+# =========================================================================
+# Tests: LEDService — GPU cycle timer
+# =========================================================================
+
+class TestGpuCycleTimer:
+    def test_init_gpu_cycle_loads_config(self):
+        svc = LEDService()
+        config = {
+            'gpu_slots': {'top': '0000:0f:00.0', 'bottom': '0000:06:00.0'},
+            'gpu_cycle_seconds': 3,
+            'gpu_active_slot': 'top',
+            'gpu_indicator_color': '#FF0000',
+        }
+        with patch("trcc.conf.load_config", return_value=config):
+            svc._init_gpu_cycle()
+        assert svc._gpu_slot_order == ['top', 'bottom']
+        assert svc._gpu_active_slot == 'top'
+        assert svc._gpu_cycle_seconds == 3
+        assert svc._gpu_indicator_color == (255, 0, 0)
+
+    def test_advance_rotates_slot(self):
+        svc = LEDService()
+        svc._gpu_slots = {'top': 'a', 'bottom': 'b'}
+        svc._gpu_slot_order = ['top', 'bottom']
+        svc._gpu_active_slot = 'top'
+        svc._gpu_cycle_seconds = 1
+        svc._gpu_cycle_ticks = 0
+        with patch("trcc.conf.load_config", return_value={}), \
+             patch("trcc.conf.save_config"):
+            # tick enough times (1s / 0.15 = ~7 ticks)
+            for _ in range(7):
+                svc._advance_gpu_cycle()
+        assert svc._gpu_active_slot == 'bottom'
+
+    def test_advance_single_slot_no_rotation(self):
+        svc = LEDService()
+        svc._gpu_slots = {'top': 'a'}
+        svc._gpu_slot_order = ['top']
+        svc._gpu_active_slot = 'top'
+        svc._gpu_cycle_seconds = 1
+        svc._gpu_cycle_ticks = 0
+        for _ in range(20):
+            svc._advance_gpu_cycle()
+        assert svc._gpu_active_slot == 'top'
+
+    def test_indicator_color_default(self):
+        svc = LEDService()
+        config = {'gpu_slots': {'top': 'a'}}
+        with patch("trcc.conf.load_config", return_value=config):
+            svc._init_gpu_cycle()
+        assert svc._gpu_indicator_color == (0, 0, 255)

--- a/tests/services/test_led.py
+++ b/tests/services/test_led.py
@@ -1334,13 +1334,23 @@ class TestGpuCycleTimer:
         svc._gpu_slot_order = ['top', 'bottom']
         svc._gpu_active_slot = 'top'
         svc._gpu_cycle_seconds = 1
-        svc._gpu_cycle_ticks = 0
+        svc._gpu_cycle_last = 0.0
         with patch("trcc.conf.load_config", return_value={}), \
-             patch("trcc.conf.save_config"):
-            # tick enough times (1s / 0.15 = ~7 ticks)
-            for _ in range(7):
-                svc._advance_gpu_cycle()
+             patch("trcc.conf.save_config"), \
+             patch("time.monotonic", return_value=10.0):
+            svc._advance_gpu_cycle()
         assert svc._gpu_active_slot == 'bottom'
+
+    def test_advance_does_not_rotate_before_interval(self):
+        svc = LEDService()
+        svc._gpu_slots = {'top': 'a', 'bottom': 'b'}
+        svc._gpu_slot_order = ['top', 'bottom']
+        svc._gpu_active_slot = 'top'
+        svc._gpu_cycle_seconds = 5
+        svc._gpu_cycle_last = 10.0
+        with patch("time.monotonic", return_value=12.0):
+            svc._advance_gpu_cycle()
+        assert svc._gpu_active_slot == 'top'
 
     def test_advance_single_slot_no_rotation(self):
         svc = LEDService()
@@ -1348,8 +1358,8 @@ class TestGpuCycleTimer:
         svc._gpu_slot_order = ['top']
         svc._gpu_active_slot = 'top'
         svc._gpu_cycle_seconds = 1
-        svc._gpu_cycle_ticks = 0
-        for _ in range(20):
+        svc._gpu_cycle_last = 0.0
+        with patch("time.monotonic", return_value=10.0):
             svc._advance_gpu_cycle()
         assert svc._gpu_active_slot == 'top'
 

--- a/tests/test_conf_gpu_slots.py
+++ b/tests/test_conf_gpu_slots.py
@@ -1,28 +1,26 @@
-from trcc.conf import Settings
+from trcc.conf import Settings, load_config
 
 
-def test_save_and_load_gpu_slots(tmp_path, monkeypatch):
+def test_set_gpu_slots_persists(tmp_path, monkeypatch):
     config_path = tmp_path / "config.json"
     monkeypatch.setattr("trcc.conf.CONFIG_PATH", str(config_path))
     slots = {"top": "0000:0f:00.0", "bottom": "0000:06:00.0"}
-    Settings._save_gpu_slots(slots)
+    Settings.set_gpu_slots(slots, 10)
     assert Settings._get_saved_gpu_slots() == slots
+    config = load_config()
+    assert config['gpu_cycle_seconds'] == 10
 
-def test_save_and_load_gpu_cycle_seconds(tmp_path, monkeypatch):
+def test_set_gpu_slots_default_cycle(tmp_path, monkeypatch):
     config_path = tmp_path / "config.json"
     monkeypatch.setattr("trcc.conf.CONFIG_PATH", str(config_path))
-    Settings._save_gpu_cycle_seconds(10)
-    assert Settings._get_saved_gpu_cycle_seconds() == 10
+    Settings.set_gpu_slots({"top": "0000:0f:00.0"}, 5)
+    config = load_config()
+    assert config['gpu_cycle_seconds'] == 5
 
-def test_gpu_cycle_seconds_default(tmp_path, monkeypatch):
+def test_set_gpu_indicator_color(tmp_path, monkeypatch):
     config_path = tmp_path / "config.json"
     monkeypatch.setattr("trcc.conf.CONFIG_PATH", str(config_path))
-    assert Settings._get_saved_gpu_cycle_seconds() == 5
-
-def test_save_and_load_gpu_indicator_color(tmp_path, monkeypatch):
-    config_path = tmp_path / "config.json"
-    monkeypatch.setattr("trcc.conf.CONFIG_PATH", str(config_path))
-    Settings._save_gpu_indicator_color("#FF0000")
+    Settings.set_gpu_indicator_color("#FF0000")
     assert Settings._get_saved_gpu_indicator_color() == "#FF0000"
 
 def test_gpu_indicator_color_default(tmp_path, monkeypatch):

--- a/tests/test_conf_gpu_slots.py
+++ b/tests/test_conf_gpu_slots.py
@@ -1,0 +1,38 @@
+from trcc.conf import Settings
+
+
+def test_save_and_load_gpu_slots(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr("trcc.conf.CONFIG_PATH", str(config_path))
+    slots = {"top": "0000:0f:00.0", "bottom": "0000:06:00.0"}
+    Settings._save_gpu_slots(slots)
+    assert Settings._get_saved_gpu_slots() == slots
+
+def test_save_and_load_gpu_cycle_seconds(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr("trcc.conf.CONFIG_PATH", str(config_path))
+    Settings._save_gpu_cycle_seconds(10)
+    assert Settings._get_saved_gpu_cycle_seconds() == 10
+
+def test_gpu_cycle_seconds_default(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr("trcc.conf.CONFIG_PATH", str(config_path))
+    assert Settings._get_saved_gpu_cycle_seconds() == 5
+
+def test_save_and_load_gpu_indicator_color(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr("trcc.conf.CONFIG_PATH", str(config_path))
+    Settings._save_gpu_indicator_color("#FF0000")
+    assert Settings._get_saved_gpu_indicator_color() == "#FF0000"
+
+def test_gpu_indicator_color_default(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr("trcc.conf.CONFIG_PATH", str(config_path))
+    assert Settings._get_saved_gpu_indicator_color() == "#0000FF"
+
+def test_gpu_pci_slot_fallback(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    monkeypatch.setattr("trcc.conf.CONFIG_PATH", str(config_path))
+    Settings._save_gpu_pci_slot("0000:0f:00.0")
+    assert Settings._get_saved_gpu_slots() == {}
+    assert Settings._get_saved_gpu_pci_slot() == "0000:0f:00.0"

--- a/tests/test_conf_gpu_slots.py
+++ b/tests/test_conf_gpu_slots.py
@@ -30,9 +30,7 @@ def test_gpu_indicator_color_default(tmp_path, monkeypatch):
     monkeypatch.setattr("trcc.conf.CONFIG_PATH", str(config_path))
     assert Settings._get_saved_gpu_indicator_color() == "#0000FF"
 
-def test_gpu_pci_slot_fallback(tmp_path, monkeypatch):
+def test_empty_gpu_slots_default(tmp_path, monkeypatch):
     config_path = tmp_path / "config.json"
     monkeypatch.setattr("trcc.conf.CONFIG_PATH", str(config_path))
-    Settings._save_gpu_pci_slot("0000:0f:00.0")
     assert Settings._get_saved_gpu_slots() == {}
-    assert Settings._get_saved_gpu_pci_slot() == "0000:0f:00.0"


### PR DESCRIPTION
## Summary

- **`trcc set-gpu`** — interactive CLI to assign up to 3 GPUs to indicator slots (top/middle/bottom) with configurable cycle interval and indicator LED color (named colors or hex)
- **PA120 GPU indicator** — leftmost GPU temp digit lights segment A/G/D to show which GPU is active
- **Instant sensor swap** — pre-built per-slot sensor ID mappings patch SystemService defaults on cycle switch; no re-enumeration, no render lag
- **Atomic config writes** — `save_config()` uses mkstemp + os.replace to prevent corruption from concurrent LED timer and GUI saves
- **Wall-clock cycle timer** — `time.monotonic()` instead of tick counting for consistent rotation timing

## Scope & limitations

- **AMD only** — tested on dual-AMD (RX 7900 XTX + RX 5700 XT). NVIDIA and Intel multi-GPU paths are stubbed with implementation guidance in comments (`sensors.py:gpu_mapping_for_pci`)
- **PA120 only** — GPU indicator LEDs and cycle init are gated behind `GPU_INDICATOR_LEDS` attribute, which only PA120Display defines. Other segment displays show GPU data but won't cycle
- **Linux only** — `detect_gpus()` reads sysfs/lspci. CLI gates with `if not LINUX`

## Architecture

- Follows hexagonal purity: LEDService uses SystemService public API (`gpu_mapping_for_pci()`, `update_gpu_defaults()`, `all_metrics` property) — no private attribute access
- `detect_gpus()` added as module-level utility in sensors.py (PCI class 0x0300/0x0302 scan + lspci name resolution + hwmon driver_key mapping)
- `_find_first_sensor()` extracted as static method on SensorEnumerator for reuse by `gpu_mapping_for_pci()`
- Config persistence: `gpu_slots`, `gpu_cycle_seconds`, `gpu_active_slot`, `gpu_indicator_color` in `~/.trcc/config.json`
- Active slot persisted in background thread to keep render path fast

## Test plan

- [x] `tests/test_conf_gpu_slots.py` — slot/color persistence, defaults
- [x] `tests/cli/test_set_gpu.py` — single GPU, multi-GPU assignment, no GPUs, empty slots
- [x] `tests/adapters/system/linux/test_gpu_cycle_mapping.py` — per-PCI sensor mapping, unknown slot, best_gpu fallback
- [x] `tests/services/test_led.py` — cycle init, wall-clock rotation, no-rotation-before-interval, single-slot no-op
- [x] `tests/core/test_led_segment.py` — PA120 indicator mask
- [x] Manual testing: dual-AMD system, CPU/GPU stress, config corruption recovery, indicator color switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)