### PR TITLE
Multi-display keep-alive + CLI device targeting

### DIFF
--- a/doc/GUIDE_MULTI_DISPLAY.md
+++ b/doc/GUIDE_MULTI_DISPLAY.md
@@ -1,0 +1,51 @@
+# Multi-Display (Multiple LCD Devices)
+
+TRCC Linux can connect to multiple compatible LCD devices at the same time.
+Each connected LCD has its own render pipeline (`Device` → `DisplayService`),
+and the GUI creates one `LCDHandler` per LCD.
+
+## What Works
+
+- Multiple LCDs show up in the GUI device sidebar.
+- You can switch which LCD is *active* (the one shown in the preview/settings panels).
+- Inactive LCDs keep their physical display updated (including video playback).
+
+## Important Detail: Shared GUI Widgets
+
+The GUI uses a single set of preview/settings widgets for the *active* device.
+Inactive devices must **not** update those widgets, but they still need to keep
+their own video timer running to pump frames to hardware.
+
+```mermaid
+sequenceDiagram
+  participant App as "TrccApp (core metrics loop)"
+  participant GUI as "GUI (TrccMainWindow)"
+  participant H1 as "LCDHandler A"
+  participant H2 as "LCDHandler B"
+  participant D1 as "Device A"
+  participant D2 as "Device B"
+
+  App->>GUI: DEVICES_CHANGED([Device A, Device B])
+  GUI->>H1: create handler(Device A)
+  GUI->>H2: create handler(Device B)
+  GUI->>H1: activate (UI owns widgets)
+  GUI->>H2: restore_inactive_state()
+  loop video timers
+    H1->>D1: video_tick() + send frame
+    H2->>D2: video_tick() + send frame
+  end
+  Note over H1,H2: Only the active handler updates shared preview/progress widgets
+```
+
+## CLI Targeting
+
+Most LCD commands accept `--device/-d` to target a specific device.
+
+- Use a device path: `trcc send -d /dev/sg2 image.png`
+- Or use the 1-based device number from `trcc detect --all`: `trcc send -d 2 image.png`
+
+## Known Limitations
+
+- Slideshow/carousel timers are tied to the active device UI state. When you switch
+  away from an LCD, its slideshow is paused. Video playback continues.
+

--- a/doc/GUIDE_USER.md
+++ b/doc/GUIDE_USER.md
@@ -220,12 +220,13 @@ Everything the GUI does, the CLI can do too. Useful for scripting, headless serv
 ```bash
 # Device management
 trcc detect              # list connected devices
-trcc select 0            # select device by index
+trcc detect --all        # list all devices + numbers
+trcc select 1            # select device by number (from detect --all)
 
 # Display
 trcc send image.png      # send an image to the LCD
 trcc theme-load Theme1   # load a theme by name
-trcc brightness 80       # set brightness to 80%
+trcc brightness 3        # brightness preset (1=25%, 2=50%, 3=100%)
 trcc rotation 90         # rotate display
 
 # LED
@@ -318,6 +319,8 @@ Verbose logging — useful for bug reports. Check `~/.trcc/trcc.log` for details
 ### Multiple Devices
 TRCC supports multiple LCD/LED devices simultaneously. Each device gets its own config, theme, and overlay settings. Click a device in the sidebar to switch.
 
+For details (including how inactive LCDs keep video playing), see `doc/GUIDE_MULTI_DISPLAY.md`.
+
 ### Brightness Schedule
 Set brightness from the CLI or API on a cron job:
 ```bash
@@ -340,6 +343,7 @@ The overlay editor uses system fonts. Install any TrueType font on your system a
 | [User Guide](GUIDE_USER.md) | This document — how to use everything |
 | [CLI Reference](REFERENCE_CLI.md) | All 60 CLI commands |
 | [API Reference](REFERENCE_API.md) | All 55 REST API endpoints |
+| [Multi-Display](GUIDE_MULTI_DISPLAY.md) | Multiple LCD devices at once |
 | [Troubleshooting](GUIDE_TROUBLESHOOTING.md) | Common problems and fixes |
 | [Device Testing](GUIDE_DEVICE_TESTING.md) | Testing with specific hardware |
 | [Supported Devices](REFERENCE_DEVICES.md) | Full device compatibility list |

--- a/doc/REFERENCE_CLI.md
+++ b/doc/REFERENCE_CLI.md
@@ -73,6 +73,11 @@ trcc select 2          # select device number 2
 
 Device numbers correspond to the `[N]` shown in `trcc detect --all`.
 
+Many LCD commands also accept `--device/-d` to override the target device.
+You can pass either:
+- A device path (example: `/dev/sg2`)
+- A 1-based device number from `trcc detect --all` (example: `--device 2`)
+
 ---
 
 ### `trcc send`
@@ -87,7 +92,7 @@ trcc send image.png --preview       # show ANSI preview in terminal
 
 | Option | Description |
 |--------|-------------|
-| `--device`, `-d` | Device path (default: auto-detect) |
+| `--device`, `-d` | Device path or `trcc detect --all` number (default: selected device) |
 | `--preview`, `-p` | Show ANSI art preview in terminal (for headless/SSH) |
 
 The image is automatically resized and cropped to fit the LCD resolution.
@@ -106,7 +111,7 @@ trcc color '#0000ff'   # blue (quote the # in shell)
 
 | Option | Description |
 |--------|-------------|
-| `--device`, `-d` | Device path (default: auto-detect) |
+| `--device`, `-d` | Device path or `trcc detect --all` number (default: selected device) |
 | `--preview`, `-p` | Show ANSI art preview in terminal |
 
 ---
@@ -124,7 +129,7 @@ trcc test --preview    # show ANSI preview for each color
 | Option | Description |
 |--------|-------------|
 | `--loop`, `-l` | Loop colors continuously (Ctrl+C to stop) |
-| `--device`, `-d` | Device path (default: auto-detect) |
+| `--device`, `-d` | Device path or `trcc detect --all` number (default: selected device) |
 | `--preview`, `-p` | Show ANSI art preview in terminal |
 
 ---
@@ -140,7 +145,7 @@ trcc reset --device /dev/sg2
 
 | Option | Description |
 |--------|-------------|
-| `--device`, `-d` | Device path (default: auto-detect) |
+| `--device`, `-d` | Device path or `trcc detect --all` number (default: selected device) |
 | `--preview`, `-p` | Show ANSI art preview in terminal |
 
 ---
@@ -556,7 +561,7 @@ trcc brightness 3       # 100%
 
 | Option | Description |
 |--------|-------------|
-| `--device`, `-d` | Device path (default: auto-detect) |
+| `--device`, `-d` | Device path or `trcc detect --all` number (default: selected device) |
 
 Persists to per-device config.
 
@@ -575,7 +580,7 @@ trcc rotation 270       # 270° clockwise
 
 | Option | Description |
 |--------|-------------|
-| `--device`, `-d` | Device path (default: auto-detect) |
+| `--device`, `-d` | Device path or `trcc detect --all` number (default: selected device) |
 
 Persists to per-device config.
 
@@ -593,7 +598,7 @@ trcc video clip.mp4 --duration 30
 
 | Option | Description |
 |--------|-------------|
-| `--device`, `-d` | Device path (default: auto-detect) |
+| `--device`, `-d` | Device path or `trcc detect --all` number (default: selected device) |
 | `--no-loop` | Play once instead of looping |
 | `--duration` | Stop after N seconds (default: 0 = forever) |
 | `--preview`, `-p` | Animate ANSI preview in terminal |
@@ -641,7 +646,7 @@ trcc theme --background animated.gif \
 | `--time-format` | Time format: 0=24h HH:MM, 1=12h hh:MM |
 | `--date-format` | Date format: 0=yyyy/MM/dd, 2=dd/MM/yyyy |
 | `--save`, `-s` | Save as named theme (e.g. `--save MyTheme`) |
-| `--device`, `-d` | Device path (default: auto-detect) |
+| `--device`, `-d` | Device path or `trcc detect --all` number (default: selected device) |
 | `--no-loop` | Play once instead of looping |
 | `--duration` | Stop after N seconds (default: 0 = forever) |
 | `--preview`, `-p` | Animate ANSI preview in terminal |
@@ -694,7 +699,7 @@ trcc screencast --fps 15
 
 | Option | Description |
 |--------|-------------|
-| `--device`, `-d` | Device path (default: auto-detect) |
+| `--device`, `-d` | Device path or `trcc detect --all` number (default: selected device) |
 | `--x`, `--y` | Top-left corner of capture region |
 | `--w`, `--h` | Width/height of capture region (0 = full screen) |
 | `--fps` | Frames per second (default: 10) |
@@ -714,7 +719,7 @@ trcc mask --clear                 # remove mask (send solid black)
 
 | Option | Description |
 |--------|-------------|
-| `--device`, `-d` | Device path (default: auto-detect) |
+| `--device`, `-d` | Device path or `trcc detect --all` number (default: selected device) |
 | `--clear` | Clear mask (send solid black) |
 | `--preview`, `-p` | Show ANSI art preview in terminal |
 
@@ -732,7 +737,7 @@ trcc overlay /path/to/theme/dir --output rendered.png
 
 | Option | Description |
 |--------|-------------|
-| `--device`, `-d` | Device path (default: auto-detect) |
+| `--device`, `-d` | Device path or `trcc detect --all` number (default: selected device) |
 | `--send`, `-s` | Send rendered result to LCD |
 | `--output`, `-o` | Save rendered image to file |
 | `--preview`, `-p` | Show ANSI art preview in terminal |
@@ -782,7 +787,7 @@ trcc theme-load warframe          # partial match
 
 | Option | Description |
 |--------|-------------|
-| `--device`, `-d` | Device path (default: auto-detect) |
+| `--device`, `-d` | Device path or `trcc detect --all` number (default: selected device) |
 | `--preview`, `-p` | Live ANSI preview in terminal (updates with metrics) |
 
 Handles both static and animated themes. Loads overlay config (DC/config.json), wires metrics, applies mask. Static themes enter a keep-alive loop; animated themes play video with overlay. `-p` shows live-updating ANSI preview for both.
@@ -800,7 +805,7 @@ trcc theme-save AnimTheme --video /path/to/clip.mp4
 
 | Option | Description |
 |--------|-------------|
-| `--device`, `-d` | Device path (default: auto-detect) |
+| `--device`, `-d` | Device path or `trcc detect --all` number (default: selected device) |
 | `--video`, `-v` | Video path for animated theme |
 
 Saves to `~/.trcc/data/theme{W}{H}/Custom_{name}/`.
@@ -1030,7 +1035,7 @@ trcc split 3                       # Dynamic Island style 3
 
 | Option | Description |
 |--------|-------------|
-| `--device`, `-d` | Device path (default: auto-detect) |
+| `--device`, `-d` | Device path or `trcc detect --all` number (default: selected device) |
 
 Only applies to non-square widescreen LCDs.
 

--- a/install.sh
+++ b/install.sh
@@ -273,11 +273,14 @@ do_install() {
     trcc_cmd="$(find_trcc_cmd)"
     info "Running: $trcc_cmd setup --yes"
     # trcc setup handles: system deps, GPU drivers, udev, SELinux, desktop entry
-    # Use env PATH to ensure ~/.local/bin is visible under sudo
+    # IMPORTANT: run as the real user so the user's site-packages/venv are visible.
+    # (If run as root, ~/.local installs won't be importable and `trcc` will crash.)
+    #
+    # Use env PATH so ~/.local/bin is visible even if the user's shell rc wasn't loaded.
     if [[ "$trcc_cmd" == PYTHONPATH=* ]]; then
-        eval "$trcc_cmd setup --yes"
+        sudo -u "$REAL_USER" -H bash -lc "PATH=\"$REAL_HOME/.local/bin:$VENV_DIR/bin:\$PATH\" $trcc_cmd setup --yes"
     else
-        PATH="$REAL_HOME/.local/bin:$VENV_DIR/bin:$PATH" "$trcc_cmd" setup --yes
+        sudo -u "$REAL_USER" -H env PATH="$REAL_HOME/.local/bin:$VENV_DIR/bin:$PATH" "$trcc_cmd" setup --yes
     fi
 
     print_success

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ remote = [
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
+    "pytest-xdist>=3.0.0",
     "ruff>=0.4.0",
     "httpx>=0.24.0",
     "types-qrcode>=7.0",

--- a/src/trcc/adapters/infra/data_repository.py
+++ b/src/trcc/adapters/infra/data_repository.py
@@ -204,7 +204,8 @@ class DataManager:
                 archive, DataManager._7z_install_help(),
             )
         except Exception as e:
-            log.warning("extract_7z: failed: %s", e)
+            log.warning("extract_7z: failed: %s: %s", type(e).__name__, e)
+            log.debug("extract_7z exception details", exc_info=True)
         return False
 
     # ------------------------------------------------------------------
@@ -249,7 +250,8 @@ class DataManager:
             log.warning("Download failed (%d): %s", e.code, url)
             e.close()
         except Exception as e:
-            log.warning("Download failed: %s", e)
+            log.warning("Download failed: %s: %s", type(e).__name__, e)
+            log.debug("Download exception details", exc_info=True)
         finally:
             if os.path.exists(tmp_path):
                 os.remove(tmp_path)
@@ -321,7 +323,13 @@ class DataManager:
             )
             return False
 
-        os.makedirs(user_dir, exist_ok=True)
+        try:
+            os.makedirs(user_dir, exist_ok=True)
+        except Exception as e:
+            log.warning("%s: cannot create %s: %s: %s",
+                        label, user_dir, type(e).__name__, e)
+            log.debug("mkdir exception details", exc_info=True)
+            return False
         if (ok := DataManager.extract_7z(archive, user_dir)):
             # Some archives wrap contents in a single subdirectory that matches
             # the target dir name (e.g. 1600720.7z contains 1600720/a001.png).
@@ -562,5 +570,4 @@ FONT_SEARCH_DIRS: List[str] = [
     '/run/current-system/sw/share/fonts/opentype',      # NixOS
     '/gnu/store/fonts',                                 # Guix (approx)
 ]
-
 

--- a/src/trcc/cli/_display.py
+++ b/src/trcc/cli/_display.py
@@ -19,7 +19,69 @@ log = logging.getLogger(__name__)
 def _connect_or_fail(device: str | None = None) -> int:
     """Connect device via discover(). Returns exit code (0 = success)."""
     from trcc.cli._connect import connect_device
+    # device option supports either a real device path (e.g. /dev/sg0) or a
+    # 1-based index from `trcc detect --all`. Indices are resolved after scan.
+    if device and device.isdigit():
+        return connect_device(None)
     return connect_device(device)
+
+
+def _sorted_devices(app):
+    def _key(d):
+        info = getattr(d, 'device_info', None)
+        idx = getattr(info, 'device_index', 0) if info else 0
+        path = getattr(info, 'path', '') if info else ''
+        return (idx, path)
+    return sorted(app.devices, key=_key)
+
+
+def _resolve_device(app, selector: str | None):
+    """Resolve a device from a selector (path or 1-based index).
+
+    Selector precedence:
+      1) Explicit selector (path or index)
+      2) Saved selection (Settings.selected_device)
+      3) First LCD device
+      4) First device (fallback)
+    """
+    from trcc.conf import Settings
+
+    devices = _sorted_devices(app)
+    if not devices:
+        return None
+
+    if selector:
+        if selector.isdigit():
+            idx = int(selector)
+            if idx < 1 or idx > len(devices):
+                return None
+            return devices[idx - 1]
+        match = app.device_by_path(selector)
+        if match is not None:
+            return match
+        # Fallback: match by DeviceInfo.path if dict key differs
+        for d in devices:
+            info = getattr(d, 'device_info', None)
+            if info and getattr(info, 'path', None) == selector:
+                return d
+        return None
+
+    saved = Settings.get_selected_device()
+    if saved:
+        match = app.device_by_path(saved)
+        if match is not None:
+            return match
+    lcd = next((d for d in devices if getattr(d, 'is_lcd', False)), None)
+    return lcd or devices[0]
+
+
+def _resolve_lcd(app, selector: str | None):
+    dev = _resolve_device(app, selector)
+    if dev is None:
+        return None, {"success": False, "error": "No device found", "message": "No device found"}
+    if not getattr(dev, 'is_lcd', False):
+        return None, {"success": False, "error": "Selected device is not an LCD", "message": "Selected device is not an LCD"}
+    return dev, None
 
 
 def _print_result(result: dict, *, preview: bool = False) -> int:
@@ -44,11 +106,11 @@ def test(device=None, loop=False, preview=False):
         if (rc := _connect_or_fail(device)):
             return rc
 
-        lcd = TrccApp.get().device(0)
-        assert lcd is not None
-        if lcd.device_path and 'led' in lcd.device_path:
-            print("LED controller with segment display — use 'trcc led' commands.")
-            return 0
+        app = TrccApp.get()
+        lcd, err = _resolve_lcd(app, device)
+        if err:
+            print(f"Error: {err.get('error', 'Unknown error')}")
+            return 1
         w, h = lcd.lcd_size
 
         colors = [
@@ -103,8 +165,11 @@ def play_video(builder, video_path, *, device=None, loop=True, duration=0,
 
         if (rc := _connect_or_fail(device)):
             return rc
-        lcd = TrccApp.get().device(0)
-        assert lcd is not None
+        app = TrccApp.get()
+        lcd, err = _resolve_lcd(app, device)
+        if err:
+            print(f"Error: {err.get('error', 'Unknown error')}")
+            return 1
 
         dev_path = lcd.device_path
         w, h = lcd.lcd_size
@@ -195,8 +260,11 @@ def screencast(builder, *, device=None, x=0, y=0, w=0, h=0, fps=10, preview=Fals
     if (rc := _connect_or_fail(device)):
         return rc
 
-    lcd = TrccApp.get().device(0)
-    assert lcd is not None
+    app = TrccApp.get()
+    lcd, err = _resolve_lcd(app, device)
+    if err:
+        print(f"Error: {err.get('error', 'Unknown error')}")
+        return 1
     lcd_w, lcd_h = lcd.lcd_size
 
     capture = builder.build_setup().get_screencast_capture(x, y, w, h)
@@ -274,7 +342,11 @@ def send_image(builder, image_path, device=None, preview=False):
     log.debug("send_image path=%s device=%s", image_path, device)
     if (rc := _connect_or_fail(device)):
         return rc
-    result = TrccApp.get().device(0).send_image(image_path)
+    app = TrccApp.get()
+    lcd, err = _resolve_lcd(app, device)
+    if err:
+        return _print_result(err)
+    result = lcd.send_image(image_path)
     return _print_result(result, preview=preview)
 
 
@@ -289,7 +361,11 @@ def send_color(builder, hex_color, device=None, preview=False):
     if (rc := _connect_or_fail(device)):
         return rc
     r, g, b = rgb
-    result = TrccApp.get().device(0).send_color(r, g, b)
+    app = TrccApp.get()
+    lcd, err = _resolve_lcd(app, device)
+    if err:
+        return _print_result(err)
+    result = lcd.send_color(r, g, b)
     return _print_result(result, preview=preview)
 
 
@@ -299,10 +375,14 @@ def set_brightness(builder, level, *, device=None):
     from trcc.core.app import TrccApp
     if (rc := _connect_or_fail(device)):
         return rc
-    try:
-        result = TrccApp.get().device(0).set_brightness(level)
-    except ValueError:
-        result = None
+    app = TrccApp.get()
+    lcd, err = _resolve_lcd(app, device)
+    if err:
+        return _print_result(err)
+
+    # Back-compat preset levels (Windows UI): 1/2/3 → 25/50/100%
+    percent = {1: 25, 2: 50, 3: 100}.get(level, level)
+    result = lcd.set_brightness(percent)
     if not result or not result.get("success"):
         error = result.get("error", "invalid brightness level") if result else "invalid brightness level"
         print(f"Error: {error}")
@@ -320,7 +400,11 @@ def set_rotation(builder, degrees, *, device=None):
     from trcc.core.app import TrccApp
     if (rc := _connect_or_fail(device)):
         return rc
-    result = TrccApp.get().device(0).set_rotation(degrees)
+    app = TrccApp.get()
+    lcd, err = _resolve_lcd(app, device)
+    if err:
+        return _print_result(err)
+    result = lcd.set_rotation(degrees)
     return _print_result(result)
 
 
@@ -330,7 +414,11 @@ def set_split_mode(builder, mode, *, device=None, preview=False):
     from trcc.core.app import TrccApp
     if (rc := _connect_or_fail(device)):
         return rc
-    result = TrccApp.get().device(0).set_split_mode(mode)
+    app = TrccApp.get()
+    lcd, err = _resolve_lcd(app, device)
+    if err:
+        return _print_result(err, preview=preview)
+    result = lcd.set_split_mode(mode)
     return _print_result(result, preview=preview)
 
 
@@ -340,7 +428,11 @@ def load_mask(builder, mask_path, *, device=None, preview=False):
     from trcc.core.app import TrccApp
     if (rc := _connect_or_fail(device)):
         return rc
-    result = TrccApp.get().device(0).load_mask_standalone(mask_path)
+    app = TrccApp.get()
+    lcd, err = _resolve_lcd(app, device)
+    if err:
+        return _print_result(err, preview=preview)
+    result = lcd.load_mask_standalone(mask_path)
     return _print_result(result, preview=preview)
 
 
@@ -355,7 +447,11 @@ def render_overlay(builder, dc_path, *, device=None, send=False, output=None,
     if (rc := _connect_or_fail(device)):
         return rc
     _ensure_system(builder)
-    result = TrccApp.get().device(0).render_overlay_from_dc(
+    app = TrccApp.get()
+    lcd, err = _resolve_lcd(app, device)
+    if err:
+        return _print_result(err)
+    result = lcd.render_overlay_from_dc(
         dc_path, send=send, output=output or None,
         metrics=get_all_metrics(),
     )
@@ -380,7 +476,10 @@ def reset(builder, device=None, *, preview=False):
     from trcc.core.app import TrccApp
     if (rc := _connect_or_fail(device)):
         return rc
-    lcd = TrccApp.get().device(0)
+    app = TrccApp.get()
+    lcd, err = _resolve_lcd(app, device)
+    if err:
+        return _print_result(err, preview=preview)
     print(f"  Device: {lcd.device_path}")
     result = lcd.reset()
     return _print_result(result, preview=preview)
@@ -418,17 +517,26 @@ def resume(builder):
         print("No compatible TRCC device detected.")
         return 1
 
-    lcd = app.device(0)
-    result = lcd.restore_last_theme()
-    if not result.get("success"):
-        print(f"Error: {result.get('error', 'Unknown error')}")
+    sent = 0
+    animated = 0
+    for dev in _sorted_devices(app):
+        if not getattr(dev, 'is_lcd', False):
+            continue
+        result = dev.restore_last_theme()
+        if not result.get("success"):
+            continue
+        sent += 1
+        if result.get("is_animated", False):
+            animated += 1
+            print(f"  [{dev.device_path}] Restored (animated — run 'trcc video -d {dev.device_path}' for playback)")
+        else:
+            print(f"  [{dev.device_path}] Sent")
+
+    if sent == 0:
         print("No themes were sent. Use the GUI to set a theme first.")
         return 1
-
-    is_animated = result.get("is_animated", False)
-    if is_animated:
-        print(f"  [{lcd.device_path}] Restored (animated — start GUI for playback)")
+    if animated:
+        print(f"Resumed {sent} device(s) ({animated} animated).")
     else:
-        print(f"  [{lcd.device_path}] Sent")
-    print("Resumed 1 device.")
+        print(f"Resumed {sent} device(s).")
     return 0

--- a/src/trcc/cli/_display.py
+++ b/src/trcc/cli/_display.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import Any, cast
 
 from trcc.cli import _cli_handler
 from trcc.core.models import parse_hex_color as _parse_hex
@@ -60,12 +61,12 @@ def _devices_snapshot(app) -> list:
         return []
 
 
-def _sorted_devices(app) -> list:
+def _sorted_devices(app: Any) -> list[Any]:
     devs = _devices_snapshot(app)
     return sorted(devs, key=lambda d: (_device_index(d), _device_path(d)))
 
 
-def _resolve_device(app, selector: str | None):
+def _resolve_device(app: Any, selector: str | None) -> Any | None:
     """Resolve a device from a selector (path or 1-based index).
 
     Selector precedence:
@@ -117,13 +118,13 @@ def _resolve_device(app, selector: str | None):
     return first_lcd or devices[0]
 
 
-def _resolve_lcd(app, selector: str | None):
+def _resolve_lcd(app: Any, selector: str | None) -> tuple[Any, dict | None]:
     dev = _resolve_device(app, selector)
     if dev is None:
         return None, {"success": False, "error": "No device found", "message": "No device found"}
     if not getattr(dev, 'is_lcd', False):
         return None, {"success": False, "error": "Selected device is not an LCD", "message": "Selected device is not an LCD"}
-    return dev, None
+    return cast(Any, dev), None
 
 
 def _print_result(result: dict, *, preview: bool = False) -> int:

--- a/src/trcc/cli/_display.py
+++ b/src/trcc/cli/_display.py
@@ -26,13 +26,43 @@ def _connect_or_fail(device: str | None = None) -> int:
     return connect_device(device)
 
 
-def _sorted_devices(app):
-    def _key(d):
-        info = getattr(d, 'device_info', None)
-        idx = getattr(info, 'device_index', 0) if info else 0
-        path = getattr(info, 'path', '') if info else ''
-        return (idx, path)
-    return sorted(app.devices, key=_key)
+def _device_path(dev) -> str:
+    """Best-effort device path for matching CLI selectors."""
+    path = getattr(dev, 'device_path', None)
+    if isinstance(path, str) and path:
+        return path
+    info = getattr(dev, 'device_info', None)
+    info_path = getattr(info, 'path', None) if info is not None else None
+    if isinstance(info_path, str) and info_path:
+        return info_path
+    return ''
+
+
+def _device_index(dev) -> int:
+    """Best-effort stable index for sorting (used by CLI numeric selectors)."""
+    info = getattr(dev, 'device_info', None)
+    idx = getattr(info, 'device_index', 0) if info is not None else 0
+    try:
+        return int(idx)
+    except Exception:
+        return 0
+
+
+def _devices_snapshot(app) -> list:
+    """Return a list of connected devices from TrccApp (or test doubles)."""
+    devs = getattr(app, 'devices', None)
+    if isinstance(devs, list):
+        return devs
+    # TrccApp.devices is a property returning list[Device]
+    try:
+        return list(devs) if devs is not None else []
+    except Exception:
+        return []
+
+
+def _sorted_devices(app) -> list:
+    devs = _devices_snapshot(app)
+    return sorted(devs, key=lambda d: (_device_index(d), _device_path(d)))
 
 
 def _resolve_device(app, selector: str | None):
@@ -47,8 +77,6 @@ def _resolve_device(app, selector: str | None):
     from trcc.conf import Settings
 
     devices = _sorted_devices(app)
-    if not devices:
-        return None
 
     if selector:
         if selector.isdigit():
@@ -56,23 +84,37 @@ def _resolve_device(app, selector: str | None):
             if idx < 1 or idx > len(devices):
                 return None
             return devices[idx - 1]
-        match = app.device_by_path(selector)
-        if match is not None:
-            return match
-        # Fallback: match by DeviceInfo.path if dict key differs
+        # Path selector — match against best-effort device path
         for d in devices:
-            info = getattr(d, 'device_info', None)
-            if info and getattr(info, 'path', None) == selector:
+            if _device_path(d) == selector:
                 return d
+        # If TrccApp provides device_by_path, try it as a last resort
+        device_by_path = getattr(app, 'device_by_path', None)
+        if callable(device_by_path):
+            try:
+                match = device_by_path(selector)
+                if match is not None:
+                    return match
+            except Exception:
+                pass
         return None
+
+    # No selector: prefer the active LCD handle (tests + UI patterns)
+    lcd = getattr(app, 'lcd', None)
+    if lcd is not None:
+        return lcd
 
     saved = Settings.get_selected_device()
     if saved:
-        match = app.device_by_path(saved)
-        if match is not None:
-            return match
-    lcd = next((d for d in devices if getattr(d, 'is_lcd', False)), None)
-    return lcd or devices[0]
+        for d in devices:
+            if _device_path(d) == saved:
+                return d
+
+    if not devices:
+        return None
+
+    first_lcd = next((d for d in devices if getattr(d, 'is_lcd', False)), None)
+    return first_lcd or devices[0]
 
 
 def _resolve_lcd(app, selector: str | None):

--- a/src/trcc/cli/_led.py
+++ b/src/trcc/cli/_led.py
@@ -34,7 +34,11 @@ def _led_call(method_name: str, preview: bool = False, **kwargs) -> int:
     if (rc := _connect_or_fail()):
         return rc
     from trcc.core.app import TrccApp
-    led = TrccApp.get().device(0)
+    app = TrccApp.get()
+    led = app.led_device
+    if led is None:
+        print("Error: No LED device found.")
+        return 1
     result = getattr(led, method_name)(**kwargs)
     return _print_result(result, preview=preview)
 
@@ -54,7 +58,12 @@ def set_color(builder, hex_color, *, preview=False):
     if (rc := _connect_or_fail()):
         return rc
     r, g, b = rgb
-    result = TrccApp.get().device(0).set_color(r, g, b)
+    app = TrccApp.get()
+    led = app.led_device
+    if led is None:
+        print("Error: No LED device found.")
+        return 1
+    result = led.set_color(r, g, b)
     return _print_result(result, preview=preview)
 
 
@@ -65,7 +74,11 @@ def set_mode(builder, mode_name, *, preview=False):
     if (rc := _connect_or_fail()):
         return rc
     from trcc.core.app import TrccApp
-    led = TrccApp.get().device(0)
+    app = TrccApp.get()
+    led = app.led_device
+    if led is None:
+        print("Error: No LED device found.")
+        return 1
     result = led.set_mode(mode_name)
     if not result["success"]:
         print(f"Error: {result['error']}")
@@ -118,7 +131,12 @@ def set_led_brightness(builder, level, *, preview=False):
     from trcc.core.app import TrccApp
     if (rc := _connect_or_fail()):
         return rc
-    result = TrccApp.get().device(0).set_brightness(level)
+    app = TrccApp.get()
+    led = app.led_device
+    if led is None:
+        print("Error: No LED device found.")
+        return 1
+    result = led.set_brightness(level)
     return _print_result(result, preview=preview)
 
 
@@ -134,7 +152,12 @@ def set_sensor_source(builder, source):
     from trcc.core.app import TrccApp
     if (rc := _connect_or_fail()):
         return rc
-    result = TrccApp.get().device(0).set_sensor_source(source)
+    app = TrccApp.get()
+    led = app.led_device
+    if led is None:
+        print("Error: No LED device found.")
+        return 1
+    result = led.set_sensor_source(source)
     return _print_result(result)
 
 
@@ -148,7 +171,12 @@ def set_zone_color(builder, zone: int, hex_color: str, *, preview: bool = False)
     if (rc := _connect_or_fail()):
         return rc
     r, g, b = rgb
-    result = TrccApp.get().device(0).set_zone_color(zone, r, g, b)
+    app = TrccApp.get()
+    led = app.led_device
+    if led is None:
+        print("Error: No LED device found.")
+        return 1
+    result = led.set_zone_color(zone, r, g, b)
     return _print_result(result, preview=preview)
 
 

--- a/src/trcc/cli/_theme.py
+++ b/src/trcc/cli/_theme.py
@@ -105,7 +105,7 @@ def list_masks():
 @_cli_handler
 def load_theme(builder, name, *, device=None, preview=False):
     """Load a theme by name and send to LCD."""
-    from trcc.cli._display import _connect_or_fail
+    from trcc.cli._display import _connect_or_fail, _resolve_lcd
     from trcc.core.app import TrccApp
     from trcc.services import ImageService
 
@@ -113,7 +113,11 @@ def load_theme(builder, name, *, device=None, preview=False):
     if (rc := _connect_or_fail(device)):
         return rc
 
-    lcd = TrccApp.get().device(0)
+    app = TrccApp.get()
+    lcd, err = _resolve_lcd(app, device)
+    if err:
+        print(f"Error: {err.get('error', 'Unknown error')}")
+        return 1
     result = lcd.load_theme_by_name(name)
 
     if not result.get("success"):
@@ -219,14 +223,18 @@ def save_theme(name, *, device=None, video=None, background=None,
     """Save current display state as a custom theme."""
     from pathlib import Path
 
-    from trcc.cli._display import _connect_or_fail
+    from trcc.cli._display import _connect_or_fail, _resolve_lcd
     from trcc.core.app import TrccApp
 
     log.debug("save_theme name=%s device=%s background=%s", name, device, background)
     if (rc := _connect_or_fail(device)):
         return rc
 
-    lcd = TrccApp.get().device(0)
+    app = TrccApp.get()
+    lcd, err = _resolve_lcd(app, device)
+    if err:
+        print(f"Error: {err.get('error', 'Unknown error')}")
+        return 1
 
     # --background / --video → load into DisplayService state
     if (bg_source := background or video):
@@ -333,7 +341,7 @@ def import_theme(file_path, *, device=None):
     from trcc.adapters.infra.dc_config import DcConfig
     from trcc.adapters.infra.dc_parser import load_config_json
     from trcc.adapters.infra.dc_writer import import_theme as _import_fn
-    from trcc.cli._display import _connect_or_fail
+    from trcc.cli._display import _connect_or_fail, _resolve_lcd
     from trcc.conf import settings as _settings
     from trcc.core.app import TrccApp
     from trcc.services import ThemeService
@@ -342,7 +350,11 @@ def import_theme(file_path, *, device=None):
     if (rc := _connect_or_fail(device)):
         return rc
 
-    lcd = TrccApp.get().device(0)
+    app = TrccApp.get()
+    lcd, err = _resolve_lcd(app, device)
+    if err:
+        print(f"Error: {err.get('error', 'Unknown error')}")
+        return 1
     w, h = lcd.lcd_size
     data_dir = _settings.user_data_dir
 

--- a/src/trcc/gui/lcd_handler.py
+++ b/src/trcc/gui/lcd_handler.py
@@ -71,6 +71,7 @@ class LCDHandler(BaseHandler):
         self._ldd_is_split = False
         self._background_active = False
         self._slideshow_index = 0
+        self._last_render_id: int | None = None
 
         # QPixmap cache keyed by frame index: {index: (id(qimage), QPixmap)}
         # Avoids QImage→QPixmap conversion on every tick when L3 cache is warm.
@@ -555,6 +556,8 @@ class LCDHandler(BaseHandler):
         """Metrics tick: video cache text update only."""
         if not self._lcd.connected or not self._lcd.playing:
             return
+        if not self._lcd.enabled:
+            return
         self.log.debug("overlay_tick: video playing — updating cache text overlay")
         self._lcd.update_video_cache_text(metrics)
 
@@ -707,6 +710,7 @@ class LCDHandler(BaseHandler):
         """Render overlay + send to LCD, update preview.
 
         Skipped when video/screencast is active — those own the device.
+        Skipped if nothing changed since last render (cache hit).
         """
         self.log.debug("_render_and_send: playing=%s overlay_enabled=%s has_image=%s",
                   self._lcd.playing, self._lcd.enabled,
@@ -716,7 +720,13 @@ class LCDHandler(BaseHandler):
         result = self._lcd.render_and_send()
         image = result.get('image')
         if image:
-            self._w['preview'].set_image(image)
+            if self._ui_active and self._is_visible():
+                self._w['preview'].set_image(image)
+            new_id = id(image)
+            if self._last_render_id == new_id:
+                self.log.debug("_render_and_send: cache hit, skipping")
+                return
+            self._last_render_id = new_id
 
     def render_and_preview(self) -> Any:
         """Render overlay and update preview (no send)."""

--- a/src/trcc/gui/lcd_handler.py
+++ b/src/trcc/gui/lcd_handler.py
@@ -127,6 +127,8 @@ class LCDHandler(BaseHandler):
         the shared preview/settings widgets (which are owned by the active handler).
         """
         self._ui_active = False
+        # Clear stale pixmap cache from any previous session so we start fresh.
+        self._pixmap_cache.clear()
         if not self._lcd.connected:
             return
         try:
@@ -488,6 +490,13 @@ class LCDHandler(BaseHandler):
                     preview_id = id(preview)
                     if cached is None or cached[0] != preview_id:
                         pixmap = QPixmap.fromImage(preview)
+                        # Evict stale entries when cache exceeds the video
+                        # frame count (or a hard cap of 512 if unknown).
+                        # Without this the dict grows unbounded for long
+                        # sessions because frame_index is ever-increasing.
+                        cap = getattr(self._lcd, 'total_frames', None) or 512
+                        if len(self._pixmap_cache) >= cap:
+                            self._pixmap_cache.clear()
                         self._pixmap_cache[index] = (preview_id, pixmap)
                     else:
                         pixmap = cached[1]
@@ -783,6 +792,7 @@ class LCDHandler(BaseHandler):
         self._animation_timer.stop()
         self._slideshow_timer.stop()
         self._flash_timer.stop()
+        self._pixmap_cache.clear()
         self._cleanup_device()
 
     def deactivate(self) -> None:

--- a/src/trcc/gui/lcd_handler.py
+++ b/src/trcc/gui/lcd_handler.py
@@ -60,6 +60,9 @@ class LCDHandler(BaseHandler):
         self._data_dir = data_dir
         self._is_visible = is_visible_fn or (lambda: True)
         self.log: logging.Logger = log  # module-level until apply_device_config
+        # UI focus state: inactive handlers must not mutate shared widgets.
+        # (Multiple LCDHandler instances share a single widget set in the GUI.)
+        self._ui_active = False
 
         # Per-device state
         self._device_key = ''
@@ -98,6 +101,7 @@ class LCDHandler(BaseHandler):
         """First-time device setup + full widget refresh."""
         self.log.info("apply_device_config: device_index=%d %04x:%04x %dx%d",
                       device.device_index, device.vid, device.pid, w, h)
+        self._ui_active = True
         self._device_key = Settings.device_config_key(
             device.device_index, device.vid, device.pid)
         # Per-device child logger — tags handler logs with device index
@@ -111,7 +115,34 @@ class LCDHandler(BaseHandler):
 
     def reactivate(self, w: int, h: int) -> None:
         """Return to known device — device already configured from connect()."""
+        self._ui_active = True
         self._refresh(w, h)
+
+    def restore_inactive_state(self) -> None:
+        """Restore last theme for an inactive LCD without touching shared widgets.
+
+        Used by multi-display scenarios: all LCDs should continue playing video
+        even when not selected in the GUI sidebar.  This method restores the
+        device state and starts the per-device video timer, but avoids updating
+        the shared preview/settings widgets (which are owned by the active handler).
+        """
+        self._ui_active = False
+        if not self._lcd.connected:
+            return
+        try:
+            self._lcd.restore_device_settings()
+            result = self._lcd.restore_last_theme()
+        except Exception:
+            self.log.exception("restore_inactive_state: failed")
+            return
+
+        if not result.get("success"):
+            return
+        if result.get("is_animated") and self._lcd.playing:
+            interval = max(1, int(self._lcd.interval or 33))
+            if not self._animation_timer.isActive():
+                self.log.info("restore_inactive_state: starting background video timer interval=%dms", interval)
+                self._animation_timer.start(interval)
 
     def _refresh(self, w: int, h: int) -> None:
         """Update widgets from the device's current state.
@@ -440,14 +471,15 @@ class LCDHandler(BaseHandler):
         if frame_index is not None and frame_index % 30 == 0:
             self.log.debug("_on_video_tick: frame=%d encoded=%s", frame_index, result.get('encoded') is not None)
 
-        # Update progress bar
-        progress = result.get('progress')
-        if progress is not None:
-            percent, current_time, total_time = progress
-            self._w['preview'].set_progress(percent, current_time, total_time)
+        # Update progress bar (active UI only — widgets are shared)
+        if self._ui_active:
+            progress = result.get('progress')
+            if progress is not None:
+                percent, current_time, total_time = progress
+                self._w['preview'].set_progress(percent, current_time, total_time)
 
-        # Skip preview update when window is minimized
-        if self._is_visible():
+        # Preview update (active UI only — widgets are shared)
+        if self._ui_active and self._is_visible():
             preview = result.get('preview')
             if preview is not None:
                 index = result.get('frame_index')
@@ -748,12 +780,19 @@ class LCDHandler(BaseHandler):
 
     def cleanup(self) -> None:
         """Stop timers and release device resources."""
-        self.deactivate()
+        self._animation_timer.stop()
+        self._slideshow_timer.stop()
+        self._flash_timer.stop()
         self._cleanup_device()
 
     def deactivate(self) -> None:
         """Pause handler — stop timers when switching away from this device."""
-        self._animation_timer.stop()
+        # Important: keep video timer running for multi-display.
+        # Inactive handlers must not update shared widgets, but should keep
+        # pumping frames to their physical device while playing.
+        self._ui_active = False
+        if not self._lcd.playing:
+            self._animation_timer.stop()
         self._slideshow_timer.stop()
         self._flash_timer.stop()
 

--- a/src/trcc/gui/trcc_app.py
+++ b/src/trcc/gui/trcc_app.py
@@ -427,9 +427,8 @@ class TRCCApp(QMainWindow):
             if path != target and isinstance(handler, LCDHandler):
                 lcd = handler.display
                 if lcd.connected and lcd.device_info:
-                    log.info("_rebuild_all_handlers: restoring inactive LCD %s", path)
-                    lcd.restore_device_settings()
-                    lcd.restore_last_theme()
+                    log.info("_rebuild_all_handlers: restoring inactive LCD %s (keep-alive)", path)
+                    handler.restore_inactive_state()
 
     def _add_handler(self, device: Any) -> None:
         """Create handler for one new device."""
@@ -470,6 +469,10 @@ class TRCCApp(QMainWindow):
                 self._ipc_server.device = device
                 if lcd_handler.display.device_service:
                     lcd_handler.display.device_service.on_frame_sent = self._ipc_server.capture_frame
+            # Multi-display: restore state on inactive devices immediately so
+            # they can keep playing video even when not selected in the UI.
+            if self._active_path and self._active_path != path:
+                lcd_handler.restore_inactive_state()
         if not added and path not in self._handlers:
             log.warning("_add_handler: unhandled device type %s path=%s — skipped",
                         type(device).__name__, path)

--- a/tests/cli/test_display_device_selection.py
+++ b/tests/cli/test_display_device_selection.py
@@ -1,0 +1,59 @@
+"""Tests for CLI per-device selection helpers in trcc.cli._display.
+
+These helpers must work with both real TrccApp and test doubles used by CLI tests.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _dev(*, idx: int, path: str, is_lcd: bool = True):
+    info = SimpleNamespace(device_index=idx, path=path)
+    return SimpleNamespace(
+        device_info=info,
+        device_path=path,
+        is_lcd=is_lcd,
+    )
+
+
+class TestResolveDevice:
+    def test_prefers_app_lcd_when_no_selector(self):
+        from trcc.cli._display import _resolve_device
+
+        a = _dev(idx=0, path="/dev/sg0")
+        b = _dev(idx=1, path="/dev/sg1")
+        app = SimpleNamespace(devices=[a, b], lcd=b)
+
+        assert _resolve_device(app, None) is b
+
+    def test_path_selector_matches_device_path(self):
+        from trcc.cli._display import _resolve_device
+
+        a = _dev(idx=0, path="/dev/sg0")
+        b = _dev(idx=1, path="/dev/sg1")
+        app = SimpleNamespace(devices=[a, b])
+
+        assert _resolve_device(app, "/dev/sg1") is b
+
+    def test_numeric_selector_uses_sorted_index(self):
+        from trcc.cli._display import _resolve_device
+
+        # Out-of-order list, but sorted by device_index then path
+        a = _dev(idx=1, path="/dev/sg9")
+        b = _dev(idx=0, path="/dev/sg0")
+        app = SimpleNamespace(devices=[a, b])
+
+        assert _resolve_device(app, "1") is b
+        assert _resolve_device(app, "2") is a
+
+    def test_saved_selection_used_when_no_app_lcd(self):
+        from trcc.cli._display import _resolve_device
+
+        a = _dev(idx=0, path="/dev/sg0")
+        b = _dev(idx=1, path="/dev/sg1")
+        app = SimpleNamespace(devices=[a, b], lcd=None)
+
+        with patch("trcc.conf.Settings.get_selected_device", return_value="/dev/sg1"):
+            assert _resolve_device(app, None) is b
+

--- a/tests/gui/test_lcd_handler.py
+++ b/tests/gui/test_lcd_handler.py
@@ -846,9 +846,33 @@ class TestLifecycle:
     """deactivate, cleanup."""
 
     def test_deactivate(self, lcd_handler):
+        lcd_handler._lcd.playing = False
         lcd_handler.deactivate()
         lcd_handler._animation_timer.stop.assert_called()
         lcd_handler._slideshow_timer.stop.assert_called()
+
+    def test_deactivate_keeps_video_timer_running(self, lcd_handler):
+        """Switching away should not pause physical video playback on other LCDs."""
+        lcd_handler._lcd.playing = True
+        lcd_handler.deactivate()
+        lcd_handler._animation_timer.stop.assert_not_called()
+        lcd_handler._slideshow_timer.stop.assert_called()
+
+    def test_restore_inactive_state_starts_video_timer(self, make_lcd_handler, mock_lcd_device):
+        """Inactive LCDs should start their animation timer after restoring an animated theme."""
+        mock_lcd_device.connected = True
+        mock_lcd_device.playing = True
+        mock_lcd_device.interval = 40
+        mock_lcd_device.restore_last_theme.return_value = {
+            'success': True,
+            'is_animated': True,
+        }
+        h = make_lcd_handler(lcd=mock_lcd_device)
+        h._animation_timer.isActive.return_value = False
+
+        h.restore_inactive_state()
+
+        h._animation_timer.start.assert_called_with(40)
 
     def test_cleanup_calls_stop(self, lcd_handler, mock_lcd_device):
         """cleanup calls stop() — ensures video state is consistent."""

--- a/tests/gui/test_lcd_handler.py
+++ b/tests/gui/test_lcd_handler.py
@@ -832,6 +832,8 @@ class TestRender:
         """_render_and_send calls render_and_send and updates preview."""
         img = MagicMock()
         mock_lcd_device.render_and_send.return_value = {'success': True, 'image': img}
+        lcd_handler._ui_active = True
+        lcd_handler._w['preview'].isVisible.return_value = True
         lcd_handler._render_and_send()
         mock_lcd_device.render_and_send.assert_called()
         lcd_handler._w['preview'].set_image.assert_called_with(img)

--- a/tools/rename_assets.py
+++ b/tools/rename_assets.py
@@ -19,8 +19,6 @@ Usage::
 from __future__ import annotations
 
 import argparse
-import re
-import sys
 from pathlib import Path
 
 # ============================================================================


### PR DESCRIPTION
## Summary

I wound up with two TRCC compatible devices on my system and only one would be serviced at a time no matter what I tried, this change made the two devices work at the same time.

- Keep inactive LCD video playback running in GUI
- Fix CLI to target the selected device (path or index)
- Run installer setup as the real user (avoids root import issues)
- Add debug stack traces for download/extract failures

## Checklist

- [ pytest tests/cli/test_display_device_selection.py tests/gui/test_lcd_handler.py::TestLifecycle passes (8 tests) ] Tests pass (`pytest -v --tb=short`)
- [x] Linter clean (`ruff check .`)
- [x] Tested on hardware (if device-specific change)
- [x] New tests added (if adding functionality)
