### PR TITLE
fix(gui+daemon): route all LCD controls through daemon in daemon mode

### DIFF
--- a/doc/GUIDE_TROUBLESHOOTING.md
+++ b/doc/GUIDE_TROUBLESHOOTING.md
@@ -260,6 +260,65 @@ trcc setup
 
 If colors are still wrong, [open an issue](https://github.com/Lexonight1/thermalright-trcc-linux/issues) with `trcc report` output.
 
+### `trccd` service running but segment/LED display is completely blank
+
+**Affected hardware:** HID LED devices — Assassin X 120R Digital, and any cooler
+using `0416:8001` (model `LED_DIGITAL`). The cooler connects and trcc reports it
+as found, but the segment display shows nothing.
+
+**Symptoms:**
+- `systemctl status trccd.service` → active (running)
+- `lsusb | grep 0416:8001` → device present
+- `trcc status` → shows device connected, brightness 100%, global on: True
+- The physical display on the cooler is blank
+
+**Cause:** `trcc daemon` (the process run by `trccd.service`) discovers devices
+and starts the IPC socket, but never calls `start_metrics_loop()`. That is the
+50ms background thread that reads sensor data and sends LED/segment frames to
+the hardware. Without it the device is connected but receives no updates — the
+display stays dark. This bug is present through at least v9.5.11.
+
+The GUI (`trcc gui`) and API server (`trcc api`) both start this loop correctly
+on launch. Only the bare `trcc daemon` command is missing the call.
+
+**Quick check** — if you see no `Frame sent` lines, the loop is not running:
+```bash
+tail -20 ~/.trcc/trcc.log | grep "Frame sent"
+```
+
+**Fix:** Add the missing `start_metrics_loop()` call to the installed daemon:
+```bash
+sudo python3 -c "
+import pathlib
+p = pathlib.Path(next(
+    __import__('importlib.util', fromlist=['util']).util.find_spec('trcc.daemon').origin
+    for _ in [None]
+))
+txt = p.read_text()
+old = '    trcc = _build_trcc()\n\n    server = IPCServer'
+new = '    trcc = _build_trcc()\n    trcc.start_metrics_loop()\n\n    server = IPCServer'
+if new in txt:
+    print('Already patched.')
+elif old in txt:
+    p.write_text(txt.replace(old, new, 1))
+    print('Patched OK')
+else:
+    print('Pattern not found — daemon.py layout may have changed. Search for _build_trcc() and add trcc.start_metrics_loop() on the next line.')
+"
+sudo systemctl restart trccd.service
+```
+
+**Verify:**
+```bash
+sleep 3 && tail -5 ~/.trcc/trcc.log
+# Should show: Frame sent: LED
+```
+
+**Note for package managers:** This patch modifies the installed `daemon.py`.
+It will be overwritten on the next `trcc-linux` upgrade — reapply after upgrades.
+
+---
+
 ### Device detected but nothing displays / sg_raw errors
 
 **Cause:** UAS (USB Attached SCSI) kernel driver interferes with LCD devices.

--- a/src/trcc/core/device/lcd.py
+++ b/src/trcc/core/device/lcd.py
@@ -641,6 +641,7 @@ class LCDDevice(Device):
         result_img = result["image"]
         if self.connected:
             self.send(result_img)
+        self._publish_frame(result_img)
         return {
             "success": True,
             "image": result_img,
@@ -796,6 +797,7 @@ class LCDDevice(Device):
 
     def set_fit_mode(self, mode: str) -> dict:
         image = self._display_svc.set_video_fit_mode(mode)
+        self._publish_frame(image)
         return {"success": True, "image": image, "message": f"Fit mode: {mode}"}
 
     @property

--- a/src/trcc/core/device/lcd_theme_workflow.py
+++ b/src/trcc/core/device/lcd_theme_workflow.py
@@ -57,6 +57,11 @@ class LCDThemeWorkflow:
         image = result.get('image')
         is_animated = result.get('is_animated', False)
 
+        # Notify subscribers (GUI preview, IPC, API websocket) that the frame
+        # changed. Safe no-op when events are not injected (CLI/standalone).
+        if not is_animated:
+            d._publish_frame(image)
+
         return {
             "success": True,
             "image": image,

--- a/src/trcc/core/lcd_commands.py
+++ b/src/trcc/core/lcd_commands.py
@@ -197,6 +197,7 @@ class LCDCommands(DeviceCommands['LCDDevice']):
 
     @command(result_cls=FrameResult)
     def apply_mask(self, lcd: int, path: Path, *, is_custom: bool = False):
+        path = Path(path)  # IPC wire delivers str; Path(Path(...)) is idempotent
         if (dev := self._get(lcd)) is None:
             return self._missing(lcd, FrameResult)
         r = dev.load_mask_standalone(str(path))

--- a/src/trcc/core/lcd_commands.py
+++ b/src/trcc/core/lcd_commands.py
@@ -104,6 +104,7 @@ class LCDCommands(DeviceCommands['LCDDevice']):
 
     @command(result_cls=ThemeResult, extras_rename={'interval': 'interval_ms'})
     def load_theme(self, lcd: int, path: Path):
+        path = Path(path)  # IPC wire delivers str; Path(Path(...)) is idempotent
         if (dev := self._get(lcd)) is None:
             return self._missing(lcd, ThemeResult)
         if not path.exists():

--- a/src/trcc/core/trcc_proxy.py
+++ b/src/trcc/core/trcc_proxy.py
@@ -109,6 +109,26 @@ class LEDFacadeProxy(_FacadeProxy):
                  timeout: float = 10.0) -> None:
         super().__init__('led', socket_path, timeout)
 
+    def snapshot(self, led_idx: int = 0) -> Any:
+        """Return an ``LEDSnapshot`` for device ``led_idx`` via meta dispatch."""
+        from ..ipc import send_manifold_request
+        from .results import LEDSnapshot
+        data = send_manifold_request(
+            "_meta", "led_snapshot", (led_idx,), {},
+            socket_path=self._socket_path, timeout=self._timeout,
+        )
+        if not data.get("success"):
+            return LEDSnapshot(
+                connected=False, style_id=0, mode=0, color=(0, 0, 0),
+                brightness=0, global_on=False, zones=[], zone_sync=False,
+                zone_sync_interval=0, selected_zone=0, segment_on=[],
+                clock_24h=True, week_sunday=False, memory_ratio=1,
+                disk_index=0, test_mode=False,
+            )
+        snap_dict = dict(data.get("snapshot", {}))
+        snap_dict['color'] = tuple(snap_dict.get('color', [0, 0, 0]))
+        return LEDSnapshot(**snap_dict)
+
 
 class ControlCenterFacadeProxy(_FacadeProxy):
     """Proxy for ``Trcc.control_center``."""
@@ -211,7 +231,8 @@ class EventBusProxy:
                         try:
                             msg = json.loads(text)
                             payload = self._desanitize_payload(
-                                msg.get("payload", ()))
+                                msg.get("payload", ()),
+                                topic=msg.get("topic", event))
                             callback(*payload)
                         except Exception:
                             log.exception(
@@ -256,7 +277,8 @@ class EventBusProxy:
             "TrccProxy clients cannot publish — events flow daemon → client. "
             "Use Trcc.events.publish from inside the daemon process.")
 
-    def _desanitize_payload(self, payload: list | tuple) -> tuple:
+    def _desanitize_payload(self, payload: list | tuple, *,
+                            topic: str = '') -> tuple:
         """Reverse :meth:`IPCServer._sanitize_payload`.
 
         Walks the payload list and unwraps any ``__surface__`` envelopes
@@ -264,16 +286,27 @@ class EventBusProxy:
         is wired, the envelope dict passes through to the callback —
         callers that don't care about surfaces (e.g. tests subscribing
         only to METRICS) are unaffected.
+
+        For the ``metrics`` topic, dicts are reconstructed into
+        ``HardwareMetrics`` dataclass instances so callers see the same
+        type they would get from a local (non-daemon) Trcc.
         """
+        from .events import Topic
         from .wire import is_surface_envelope, unwrap_surface
 
-        if self._renderer is None:
-            return tuple(payload)
-        return tuple(
-            unwrap_surface(self._renderer, item)
-            if is_surface_envelope(item) else item
-            for item in payload
-        )
+        def _restore(item: Any) -> Any:
+            if topic == Topic.METRICS and isinstance(item, dict):
+                from .models.sensor import HardwareMetrics
+                import dataclasses as _dc
+                known = {f.name for f in _dc.fields(HardwareMetrics)}
+                d = {k: (set(v) if k == '_populated' and isinstance(v, list) else v)
+                     for k, v in item.items() if k in known}
+                return HardwareMetrics(**d)
+            if self._renderer is not None and is_surface_envelope(item):
+                return unwrap_surface(self._renderer, item)
+            return item
+
+        return tuple(_restore(item) for item in payload)
 
     def cleanup(self) -> None:
         """Close every open subscription. Idempotent.
@@ -385,6 +418,21 @@ class TrccProxy:
     def led_devices(self) -> tuple:
         """Empty in daemon mode — use ``led_descriptors()`` for identity."""
         return ()
+
+    @property
+    def settings(self) -> Any:
+        """Local user settings — reads from the per-user config file.
+
+        TrccProxy clients (GUI / CLI) share the same settings file as the
+        daemon, so the global ``conf.settings`` singleton is the right source.
+        Lazily initializes it if the composition root skipped ``init_settings``.
+        """
+        from .. import conf
+        if conf.settings is None:
+            from ..adapters.system import PlatformFactory
+            from ..conf import init_settings
+            init_settings(PlatformFactory.current())
+        return conf.settings
 
     def lcd_descriptors(self) -> list[Any]:
         """Mirror of ``Trcc.lcd_descriptors`` — fetched over IPC.

--- a/src/trcc/core/trcc_proxy.py
+++ b/src/trcc/core/trcc_proxy.py
@@ -137,6 +137,27 @@ class ControlCenterFacadeProxy(_FacadeProxy):
                  timeout: float = 10.0) -> None:
         super().__init__('control_center', socket_path, timeout)
 
+    def snapshot(self) -> Any:
+        """Return an ``AppSnapshot`` via meta dispatch (not manifold)."""
+        from ..ipc import send_manifold_request
+        from .results import AppSnapshot
+        data = send_manifold_request(
+            "_meta", "app_snapshot", (), {},
+            socket_path=self._socket_path, timeout=self._timeout,
+        )
+        if not data.get("success"):
+            from ..__version__ import __version__
+            return AppSnapshot(
+                version=__version__, autostart=False, temp_unit='C',
+                language='en', hdd_enabled=False, refresh_interval=5,
+                gpu_device=None, gpu_list=[], install_method='pip',
+                distro='unknown',
+            )
+        snap_dict = dict(data.get("snapshot", {}))
+        # JSON turns tuples into lists; restore gpu_list element type.
+        snap_dict['gpu_list'] = [tuple(item) for item in snap_dict.get('gpu_list', [])]
+        return AppSnapshot(**snap_dict)
+
 
 # =============================================================================
 # EventBusProxy — subscribe over IPC. R5 wires the long-lived connection.

--- a/src/trcc/daemon.py
+++ b/src/trcc/daemon.py
@@ -67,6 +67,12 @@ def run_daemon(*, verbosity: int = 0) -> int:
     qapp = _build_qapp()
     trcc = _build_trcc()
 
+    # Start the 50ms tick + sensor-poll loop. Without this nothing drives
+    # the LED segment display / LCD frames in daemon mode and the device
+    # shows a frozen / blank screen. Safe because _build_trcc() builds with
+    # an explicit platform, so system_svc is injected.
+    trcc.start_metrics_loop()
+
     # Renderer flows through so ``Topic.FRAME`` surface payloads get
     # encoded into a JSON-safe envelope before reaching TrccProxy clients.
     server = IPCServer(trcc=trcc, renderer=trcc.renderer)
@@ -179,7 +185,12 @@ def _build_trcc() -> Any:
     set, and theme/data callables injected.
     """
     from ._boot import trcc as _boot_trcc
-    return _boot_trcc(discover_now=True)
+    from .adapters.system import PlatformFactory
+    # Pass an explicit platform so _boot.trcc() skips the daemon-proxy
+    # short circuit. With platform=None and TRCC_DAEMON=1 inherited, that
+    # branch calls ensure_daemon() before our own socket is bound, which
+    # spawns another `trcc daemon` → fork bomb (upstream issue #162).
+    return _boot_trcc(PlatformFactory.current(), discover_now=True)
 
 
 # Module-level holder so the Qt heartbeat timer survives past the function

--- a/src/trcc/ipc.py
+++ b/src/trcc/ipc.py
@@ -570,6 +570,17 @@ class IPCServer:
             except Exception as e:
                 log.exception("_meta.led_snapshot failed")
                 return {"success": False, "error": f"{type(e).__name__}: {e}"}
+        if method == "app_snapshot":
+            try:
+                import dataclasses as _dc
+                snap = self._trcc.control_center.snapshot()
+                d = _dc.asdict(snap)
+                # gpu_list: list[tuple[str, str]] — dataclasses.asdict converts
+                # tuples to lists, which is fine for JSON. Client restores them.
+                return {"success": True, "snapshot": d}
+            except Exception as e:
+                log.exception("_meta.app_snapshot failed")
+                return {"success": False, "error": f"{type(e).__name__}: {e}"}
         return {"success": False,
                 "error": f"Unknown _meta method: {method}"}
 

--- a/src/trcc/ipc.py
+++ b/src/trcc/ipc.py
@@ -45,6 +45,19 @@ log = logging.getLogger(__name__)
 _SOCK_NAME = "trcc-linux.sock"
 
 
+def _json_default(obj: Any) -> Any:
+    """JSON serializer fallback for types not handled by the default encoder.
+
+    Handles: set → sorted list, dataclass → dict.  Keeps wire payloads
+    clean without requiring callers to enumerate every edge-case type.
+    """
+    if isinstance(obj, set):
+        return sorted(obj)
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return dataclasses.asdict(obj)
+    raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
+
+
 def _socket_path() -> Path:
     return Path(os.environ.get("XDG_RUNTIME_DIR", "/tmp")) / _SOCK_NAME
 
@@ -307,27 +320,53 @@ class IPCServer:
         # client. On write failure, unsubscribes itself.
         sub_id_holder: list[int] = []
 
+        def _cleanup_sub() -> None:
+            """Unsubscribe and close socket for this subscription."""
+            if not sub_id_holder:
+                return
+            sid = sub_id_holder[0]
+            try:
+                self._trcc.events.unsubscribe(sid)
+            except Exception:
+                log.exception("subscribe forwarder: unsubscribe raised")
+            self._event_subs[:] = [
+                (i, c) for (i, c) in self._event_subs if i != sid
+            ]
+            try:
+                client.close()
+            except OSError:
+                log.debug("subscribe forwarder: client.close() failed",
+                          exc_info=True)
+
         def _forward(*payload: Any) -> None:
             wire_payload = self._sanitize_payload(topic, payload)
-            line = json.dumps({"topic": topic, "payload": wire_payload}) + "\n"
+            try:
+                line = json.dumps({"topic": topic, "payload": wire_payload},
+                                  default=_json_default) + "\n"
+            except (TypeError, ValueError):
+                log.warning("_forward: payload for %r is not JSON-serializable — skipping", topic)
+                return
             try:
                 client.sendall(line.encode())
             except OSError:
-                if not sub_id_holder:
-                    return
-                sid = sub_id_holder[0]
-                try:
-                    self._trcc.events.unsubscribe(sid)
-                except Exception:
-                    log.exception("subscribe forwarder: unsubscribe raised")
-                self._event_subs[:] = [
-                    (i, c) for (i, c) in self._event_subs if i != sid
-                ]
-                try:
-                    client.close()
-                except OSError:
-                    log.debug("subscribe forwarder: client.close() failed",
-                              exc_info=True)
+                _cleanup_sub()
+                return
+            # Detect half-closed connections (CLOSE_WAIT) quickly: a
+            # non-blocking recv returning b'' means the remote side
+            # has closed, even though sendall still succeeds.
+            try:
+                client.setblocking(False)
+                data = client.recv(1)
+                client.setblocking(True)
+                if data == b'':
+                    log.debug("subscribe forwarder: remote closed (EOF on recv) — cleaning up")
+                    _cleanup_sub()
+            except BlockingIOError:
+                # No data available — connection is alive
+                client.setblocking(True)
+            except OSError:
+                client.setblocking(True)
+                _cleanup_sub()
 
         sub_id = self._trcc.events.subscribe(topic, _forward)
         sub_id_holder.append(sub_id)
@@ -337,15 +376,14 @@ class IPCServer:
     def _sanitize_payload(self, topic: str, payload: tuple) -> list:
         """Return *payload* in JSON-safe form for transmission.
 
-        Only ``Topic.FRAME`` carries a non-JSON-safe value today: the
-        rendered surface at index 1.  When a renderer is wired in, the
-        surface is wrapped via :func:`trcc.core.wire.wrap_surface`; when
-        not, the surface slot is replaced with ``None`` and a one-shot
-        warning is logged so misconfiguration surfaces during smoke tests
-        rather than as silent dropped frames in production.
+        Only ``Topic.FRAME`` carries a non-JSON-safe value: the rendered
+        surface at index 1.  When a renderer is wired in, the surface is
+        wrapped via :func:`trcc.core.wire.wrap_surface`; when not, the
+        surface slot is replaced with ``None``.
 
-        Other topics flow untouched — their payloads are already JSON-safe
-        (strings, ints, lists, dataclasses-as-dicts).
+        Other topics pass through as a plain list — any remaining
+        non-JSON types are handled by the ``_json_default`` encoder in
+        the caller (``_forward``).
         """
         from .core.events import Topic
 
@@ -355,6 +393,13 @@ class IPCServer:
         # Topic.FRAME contract: (device_path: str, surface: Any | None).
         # Only index 1 needs sanitizing; index 0 is already a string.
         if len(payload) < 2 or payload[1] is None:
+            return list(payload)
+
+        surface = payload[1]
+
+        # LED FRAME events carry a dict (color data) which is already
+        # JSON-safe.  Only Qt surface objects need encode_for_wire.
+        if not hasattr(surface, 'save'):
             return list(payload)
 
         if self._renderer is None:
@@ -369,7 +414,7 @@ class IPCServer:
 
         from .core.wire import wrap_surface
         try:
-            envelope = wrap_surface(self._renderer, payload[1])
+            envelope = wrap_surface(self._renderer, surface)
         except Exception:
             log.exception("_sanitize_payload: encode_for_wire raised — "
                           "dropping surface payload")
@@ -514,6 +559,17 @@ class IPCServer:
                         "error": f"{type(e).__name__}: {e}"}
             return {"success": True,
                     "descriptors": [info.to_wire_dict() for info in infos]}
+        if method == "led_snapshot":
+            try:
+                import dataclasses as _dc
+                idx = int(args[0]) if args else 0
+                snap = self._trcc.led.snapshot(idx)
+                d = _dc.asdict(snap)
+                d['color'] = list(d['color'])
+                return {"success": True, "snapshot": d}
+            except Exception as e:
+                log.exception("_meta.led_snapshot failed")
+                return {"success": False, "error": f"{type(e).__name__}: {e}"}
         return {"success": False,
                 "error": f"Unknown _meta method: {method}"}
 

--- a/src/trcc/ui/cli/_status.py
+++ b/src/trcc/ui/cli/_status.py
@@ -82,9 +82,12 @@ def status(json_output: bool = False) -> int:
     """Print a full overview: app state + every connected device."""
     trcc = _boot_trcc()
     app_snap = trcc.control_center.snapshot()
-    discovery = trcc.discover()
-    lcd_snaps = [trcc.lcd.snapshot(i) for i in range(len(discovery.lcd_devices))]
-    led_snaps = [trcc.led.snapshot(i) for i in range(len(discovery.led_devices))]
+    trcc.discover()
+    # Use descriptors (works in both in-process and daemon-proxy mode).
+    # discovery.lcd_devices / led_devices are always empty via TrccProxy
+    # because live device objects don't travel over the wire.
+    lcd_snaps = [trcc.lcd.snapshot(i) for i in range(len(trcc.lcd_descriptors()))]
+    led_snaps = [trcc.led.snapshot(i) for i in range(len(trcc.led_descriptors()))]
 
     if json_output:
         return _echo_json({

--- a/src/trcc/ui/gui/__init__.py
+++ b/src/trcc/ui/gui/__init__.py
@@ -101,17 +101,24 @@ def launch(verbosity: int = 0, decorated: bool = False,
 
     # ── Build Trcc with the windowed QApp's renderer; defer discovery so
     # the splash can show progress while USB connect + theme extraction
-    # run in BootstrapWorker.
-    from trcc._boot import trcc as _boot_trcc
+    # run in BootstrapWorker.  In daemon mode pass platform=None so
+    # _boot.trcc() takes the TrccProxy short-circuit instead of
+    # creating a new Trcc that would compete over the USB device.
+    from trcc._boot import daemon_mode_enabled, trcc as _boot_trcc
     from trcc.adapters.render.qt import QtRenderer
     renderer = QtRenderer()
-    t = _boot_trcc(platform, renderer=renderer,
-                   discover_now=False, verbosity=verbosity)
+    _daemon_mode = daemon_mode_enabled()
+    if _daemon_mode:
+        t = _boot_trcc(None, renderer=renderer, discover_now=False, verbosity=verbosity)
+    else:
+        t = _boot_trcc(platform, renderer=renderer,
+                       discover_now=False, verbosity=verbosity)
 
-    # ── Splash + background discover ─────────────────────────────────────
-    from trcc.ui.gui.splash import run_bootstrap_with_splash
-    if not run_bootstrap_with_splash(t):
-        return 1
+    # ── Splash + background discover (non-daemon only) ────────────────────
+    if not _daemon_mode:
+        from trcc.ui.gui.splash import run_bootstrap_with_splash
+        if not run_bootstrap_with_splash(t):
+            return 1
 
     # ── GUI adapter — pulls Trcc handle via _boot.trcc() (cached)  ───────
     from trcc.ui.gui.trcc_app import TRCCApp as _TRCCApp
@@ -123,21 +130,27 @@ def launch(verbosity: int = 0, decorated: bool = False,
     # ── IPC server bound to Trcc — manifold dispatch for clients ────────
     # Renderer is forwarded so Topic.FRAME events get their surface payload
     # encoded into a JSON-safe envelope before reaching TrccProxy clients.
-    from trcc.ipc import IPCServer
-    ipc_server = IPCServer(trcc=t, renderer=renderer)
-    ipc_server.start()
-    window._ipc_server = ipc_server
+    # In daemon mode the daemon already owns the socket — don't rebind it.
+    from trcc.core.trcc_proxy import TrccProxy as _TrccProxy
+    if not isinstance(t, _TrccProxy):
+        from trcc.ipc import IPCServer
+        ipc_server = IPCServer(trcc=t, renderer=renderer)
+        ipc_server.start()
+        window._ipc_server = ipc_server
 
     # ── Replay device list to the window — subscribers run in __init__,
     # so they missed the publish that happened during discover. ─────────
     from itertools import chain
 
     from trcc.core.events import Topic
-    t.events.publish(
-        Topic.DEVICE_LIST,
-        tuple(chain(t.lcd_devices, t.led_devices)),
-    )
-    t.start_metrics_loop()
+    if isinstance(t, _TrccProxy):
+        window.populate_from_descriptors()
+    else:
+        t.events.publish(
+            Topic.DEVICE_LIST,
+            tuple(chain(t.lcd_devices, t.led_devices)),
+        )
+        t.start_metrics_loop()
 
     # ── IPC raise + signals ───────────────────────────────────────────────
     signal.signal(signal.SIGINT, lambda *_: qapp.quit())

--- a/src/trcc/ui/gui/base_handler.py
+++ b/src/trcc/ui/gui/base_handler.py
@@ -22,9 +22,10 @@ log = logging.getLogger(__name__)
 class BaseHandler:
     """Shared handler interface — holds a ``Device``, routes mutual methods."""
 
-    def __init__(self, device: Device, view: str) -> None:
+    def __init__(self, device: Device | None, view: str) -> None:
         self._device = device
         self._view = view
+        self._device_info_override: DeviceInfo | None = None
 
     @property
     def view_name(self) -> str:
@@ -37,6 +38,8 @@ class BaseHandler:
 
     @property
     def device_info(self) -> DeviceInfo | None:
+        if self._device_info_override is not None:
+            return self._device_info_override
         return self._device.device_info if self._device else None
 
     def deactivate(self) -> None:

--- a/src/trcc/ui/gui/lcd_handler.py
+++ b/src/trcc/ui/gui/lcd_handler.py
@@ -294,6 +294,15 @@ class LCDHandler(BaseHandler):
         """Select theme and handle result."""
         self.log.info("Theme selected: %s (animated=%s)", theme.name, theme.is_animated)
         self._pixmap_cache.clear()
+
+        if self._app is not None:
+            # Daemon mode: route through facade — daemon owns USB + render.
+            # Frame arrives via Topic.FRAME subscription; preview updates there.
+            r = self._app.lcd.load_theme(self._lcd_idx, theme.path)
+            if not r.success:
+                self.log.warning("_select_theme: daemon load_theme failed: %s", r.error)
+            return
+
         payload = self._lcd.select(theme)
         image = payload.get('image')
         is_animated = payload.get('is_animated', False)

--- a/src/trcc/ui/gui/lcd_handler.py
+++ b/src/trcc/ui/gui/lcd_handler.py
@@ -254,6 +254,20 @@ class LCDHandler(BaseHandler):
     def _restore_theme_and_preview(self, cfg: dict) -> None:
         """Restore last theme + overlay, or clear preview if none."""
         self.log.debug("_restore_theme_and_preview: cfg keys=%s", list(cfg.keys()))
+        if self._app is not None:
+            r = self._app.lcd.restore_last_theme(self._lcd_idx)
+            if not r.success:
+                self.log.info("_restore_theme_and_preview: daemon restore failed: %s",
+                              r.error)
+                self._w['preview'].set_image(None)
+            # Frame arrives via Topic.FRAME; read overlay state from local cfg
+            overlay_cfg = cfg.get('overlay', {})
+            overlay_config = overlay_cfg.get('config')
+            overlay_enabled = overlay_cfg.get('enabled', False)
+            if overlay_config:
+                self._w['theme_setting'].load_from_overlay_config(overlay_config)
+            self._w['theme_setting'].set_overlay_enabled(overlay_enabled)
+            return
         result = self._lcd.restore_last_theme()
         if not result.get("success"):
             self.log.info("_restore_theme_and_preview: no saved theme — %s",
@@ -396,8 +410,8 @@ class LCDHandler(BaseHandler):
             # Trcc.lcd.apply_mask persists mask_id/mask_custom itself.
             is_custom = getattr(mask_info, 'is_custom', False)
             if self._app is not None:
-                r = self._app.lcd.apply_mask(self._lcd_idx, mask_dir, is_custom=is_custom)
-                image = r.frame.native if r.frame else None
+                self._app.lcd.apply_mask(self._lcd_idx, mask_dir, is_custom=is_custom)
+                image = None  # frame arrives via Topic.FRAME subscription
             else:
                 result = self._lcd.load_mask_standalone(str(mask_dir))
                 image = result.get('image')
@@ -530,8 +544,8 @@ class LCDHandler(BaseHandler):
 
     def set_video_fit_mode(self, mode: str) -> None:
         if self._app is not None:
-            r = self._app.lcd.set_fit_mode(self._lcd_idx, mode)
-            image = r.frame.native if r.frame else None
+            self._app.lcd.set_fit_mode(self._lcd_idx, mode)
+            image = None  # frame arrives via Topic.FRAME subscription
         else:
             result = self._lcd.set_fit_mode(mode)
             image = result.get('image')
@@ -651,8 +665,8 @@ class LCDHandler(BaseHandler):
         self.log.debug("set_brightness: %d%%", percent)
         self._brightness_level = percent
         if self._app is not None:
-            r = self._app.lcd.set_brightness(self._lcd_idx, percent)
-            image = r.frame.native if r.frame else None
+            self._app.lcd.set_brightness(self._lcd_idx, percent)
+            image = None  # frame arrives via Topic.FRAME subscription
         else:
             result = self._lcd.set_brightness(percent)
             image = result.get('image')
@@ -664,8 +678,8 @@ class LCDHandler(BaseHandler):
     def set_rotation(self, degrees: int) -> None:
         self.log.debug("set_rotation: degrees=%d", degrees)
         if self._app is not None:
-            r = self._app.lcd.set_rotation(self._lcd_idx, degrees)
-            image = r.frame.native if r.frame else None
+            self._app.lcd.set_rotation(self._lcd_idx, degrees)
+            image = None  # frame arrives via Topic.FRAME subscription
         else:
             result = self._lcd.set_rotation(degrees)
             image = result.get('image')
@@ -719,8 +733,8 @@ class LCDHandler(BaseHandler):
         self.log.debug("set_split_mode: mode=%d", mode)
         self._split_mode = mode
         if self._app is not None:
-            r = self._app.lcd.set_split_mode(self._lcd_idx, mode)
-            image = r.frame.native if r.frame else None
+            self._app.lcd.set_split_mode(self._lcd_idx, mode)
+            image = None  # frame arrives via Topic.FRAME subscription
         else:
             result = self._lcd.set_split_mode(mode)
             image = result.get('image')

--- a/src/trcc/ui/gui/led_handler.py
+++ b/src/trcc/ui/gui/led_handler.py
@@ -10,6 +10,10 @@ by the metrics signal (same refresh rate as LCD overlay), not a
 separate timer.
 
 Hardware sends happen in the background metrics loop via device.tick().
+
+Daemon mode (10C.6): pass ``led=None, trcc=<TrccProxy>, led_idx=n,
+descriptor=<DeviceInfo>`` to route all writes through the command bus
+instead of holding a live ``LEDDevice`` reference.
 """
 from __future__ import annotations
 
@@ -44,14 +48,24 @@ class LEDHandler(BaseHandler):
 
     def __init__(
         self,
-        led: LEDDevice,
+        led: LEDDevice | None,
         panel: UCLedControl,
         on_temp_unit_changed: Any,
+        *,
+        trcc: Any = None,
+        led_idx: int = 0,
+        descriptor: DeviceInfo | None = None,
     ) -> None:
         super().__init__(led, 'led')
         self._panel = panel
         self._on_temp_unit_changed = on_temp_unit_changed
         self._led = led
+        self._daemon_mode = trcc is not None and led is None
+        self._trcc = trcc
+        self._led_idx = led_idx
+        self._segment_on: list[bool] = []
+        if self._daemon_mode and descriptor is not None:
+            self._device_info_override = descriptor
         self._active = False
         self._style_id = 0
         self._metrics_count = 0
@@ -61,19 +75,22 @@ class LEDHandler(BaseHandler):
         """Save config and release device resources."""
         log.info("LED: cleanup")
         self._active = False
-        if self._led:
+        if not self._daemon_mode and self._led:
             self._led.save_config()
             self._led.cleanup()
 
     def update_metrics(self, metrics: Any) -> None:
         """Update panel text (segment displays). Colors arrive via FRAME_RENDERED."""
-        if not (self._led and self._active):
+        if not self._active:
+            return
+        if not self._daemon_mode and not self._led:
             return
         self._panel.update_metrics(metrics)
-        self._metrics_count += 1
-        if self._metrics_count >= self._SAVE_INTERVAL:
-            self._metrics_count = 0
-            self._led.save_config()
+        if not self._daemon_mode and self._led:
+            self._metrics_count += 1
+            if self._metrics_count >= self._SAVE_INTERVAL:
+                self._metrics_count = 0
+                self._led.save_config()
 
     # ── Public API ───────────────────────────────────────────────────
 
@@ -83,7 +100,7 @@ class LEDHandler(BaseHandler):
 
     @property
     def has_controller(self) -> bool:
-        return self._led is not None
+        return self._led is not None or self._daemon_mode
 
     @property
     def led_port(self) -> LEDDevice | None:
@@ -93,19 +110,21 @@ class LEDHandler(BaseHandler):
         """Activate handler — initialize device, sync panel from device state."""
         model = device.model or ''
         led_style = device.led_style_id or LED_STYLES.by_name(model)
-
-        self._led.initialize_led(device, led_style)
         self._style_id = led_style
 
         style_info = LED_STYLES[led_style]
         self._panel.initialize(
             led_style, style_info.segment_count, style_info.zone_count,
             model=model,
-            )
-        self._panel.set_memory_ratio(self._led.state.memory_ratio)
-        self._sync_ui_from_state()
+        )
 
-        self._led.set_temp_unit(_trcc().settings.temp_unit)
+        if self._daemon_mode:
+            self._sync_ui_from_state()
+        else:
+            self._led.initialize_led(device, led_style)
+            self._panel.set_memory_ratio(self._led.state.memory_ratio)
+            self._sync_ui_from_state()
+            self._led.set_temp_unit(_trcc().settings.temp_unit)
 
         self._active = True
         log.info("LED: show model=%s style=%d, active (metrics-driven)", model, led_style)
@@ -114,17 +133,40 @@ class LEDHandler(BaseHandler):
         """Pause handler — stop panel updates, save config. LEDDevice keeps running."""
         log.info("LED: deactivate (was active=%s)", self._active)
         self._active = False
-        if self._led:
+        if not self._daemon_mode and self._led:
             self._led.save_config()
 
     def set_temp_unit(self, unit: int) -> None:
-        if self._led:
+        if not self._daemon_mode and self._led:
             log.debug("LED: temp_unit=%d", unit)
             self._led.set_temp_unit(unit)
 
     # ── Private ──────────────────────────────────────────────────────
 
     def _sync_ui_from_state(self) -> None:
+        if self._daemon_mode:
+            try:
+                snap = self._trcc.led.snapshot(self._led_idx)
+            except Exception:
+                log.warning("LED: snapshot failed in daemon mode", exc_info=True)
+                return
+            self._segment_on = list(snap.segment_on)
+            if snap.zones:
+                z = snap.zones[0]
+                self._panel.load_zone_state(
+                    0, z['mode'], tuple(z['color']), z['brightness'], z.get('on', True))
+            else:
+                self._panel.load_zone_state(
+                    0, snap.mode, snap.color, snap.brightness, snap.global_on)
+            if snap.zone_sync and snap.zones:
+                interval_secs = max(1, round(snap.zone_sync_interval * 150 / 1000))
+                zone_sync_zones = [True] * len(snap.zones)
+                self._panel.load_sync_state(snap.zone_sync, zone_sync_zones, interval_secs)
+            self._panel.set_memory_ratio(snap.memory_ratio)
+            log.debug("LED: synced UI from snapshot (zones=%d, sync=%s)",
+                      len(snap.zones), snap.zone_sync)
+            return
+
         if not self._led:
             return
         state = self._led.state
@@ -145,14 +187,14 @@ class LEDHandler(BaseHandler):
                   len(state.zones), state.zone_sync)
 
     def _guard(self, fn):
-        """Wrap a slot so it only fires when this handler is active with a device."""
+        """Wrap a slot so it only fires when this handler is active."""
         def wrapper(*args, **kwargs):
-            if self._led and self._active:
+            if self._active and (self._daemon_mode or self._led):
                 fn(*args, **kwargs)
         return wrapper
 
     def _connect_signals(self) -> None:
-        if not self._led:
+        if not self._led and not self._daemon_mode:
             return
         p = self._panel
         p.mode_changed.connect(self._guard(self._on_mode_changed))
@@ -173,29 +215,59 @@ class LEDHandler(BaseHandler):
         p.test_mode_changed.connect(self._guard(self._on_test_mode_changed))
 
     def _on_mode_changed(self, mode: Any) -> None:
+        if self._daemon_mode:
+            self._trcc.led.set_mode(self._led_idx, mode)
+            return
         self._led.update_mode(mode)
         if self._led.state.zones:
             self._led.update_zone_mode(self._panel.selected_zone, mode)
         self._metrics_count = self._SAVE_INTERVAL  # force save on next update
 
     def _on_color_changed(self, r: int, g: int, b: int) -> None:
+        if self._daemon_mode:
+            self._trcc.led.set_color(self._led_idx, r, g, b)
+            return
         self._led.update_color(r, g, b)
         if self._led.state.zones:
             self._led.update_zone_color(self._panel.selected_zone, r, g, b)
 
     def _on_brightness_changed(self, val: int) -> None:
+        if self._daemon_mode:
+            self._trcc.led.set_brightness(self._led_idx, val)
+            return
         self._led.update_brightness(val)
         if self._led.state.zones:
             self._led.update_zone_brightness(self._panel.selected_zone, val)
 
     def _on_global_toggled(self, on: bool) -> None:
+        if self._daemon_mode:
+            self._trcc.led.toggle(self._led_idx, on)
+            return
         self._led.update_global_on(on)
 
     def _on_segment_clicked(self, idx: int) -> None:
+        if self._daemon_mode:
+            if 0 <= idx < len(self._segment_on):
+                new_val = not self._segment_on[idx]
+                self._segment_on[idx] = new_val
+                self._trcc.led.toggle_segment(self._led_idx, idx, new_val)
+            return
         if 0 <= idx < len(self._led.state.segment_on):
             self._led.update_segment(idx, not self._led.state.segment_on[idx])
 
     def _on_zone_selected(self, zone_index: int) -> None:
+        if self._daemon_mode:
+            self._trcc.led.select_zone(self._led_idx, zone_index)
+            try:
+                snap = self._trcc.led.snapshot(self._led_idx)
+                if snap.zones and 0 <= zone_index < len(snap.zones):
+                    z = snap.zones[zone_index]
+                    self._panel.load_zone_state(
+                        zone_index, z['mode'], tuple(z['color']),
+                        z['brightness'], z.get('on', True))
+            except Exception:
+                pass
+            return
         if not self._led.state.zones:
             return
         self._led.update_selected_zone(zone_index)
@@ -205,28 +277,55 @@ class LEDHandler(BaseHandler):
             self._panel.load_zone_state(zone_index, z.mode.value, z.color, z.brightness, z.on)
 
     def _on_zone_toggled(self, zi: int, on: bool) -> None:
+        if self._daemon_mode:
+            log.debug("LED daemon: zone_toggled zi=%d on=%s — not supported via proxy", zi, on)
+            return
         self._led.update_zone_on(zi, on)
 
     def _on_carousel_changed(self, on: bool) -> None:
+        if self._daemon_mode:
+            self._trcc.led.set_zone_sync(self._led_idx, on)
+            return
         self._led.update_zone_sync(on)
 
     def _on_carousel_zone_changed(self, zi: int, sel: Any) -> None:
+        if self._daemon_mode:
+            log.debug("LED daemon: carousel_zone_changed zi=%d sel=%s", zi, sel)
+            return
         self._led.update_zone_sync_zone(zi, sel)
 
     def _on_carousel_interval_changed(self, secs: int) -> None:
+        if self._daemon_mode:
+            self._trcc.led.set_zone_sync(self._led_idx, True, interval_s=secs)
+            return
         self._led.update_zone_sync_interval(secs)
 
     def _on_clock_format_changed(self, is_24h: bool) -> None:
+        if self._daemon_mode:
+            self._trcc.led.set_clock_format(self._led_idx, is_24h)
+            return
         self._led.update_clock_format(is_24h)
 
     def _on_week_start_changed(self, is_sun: bool) -> None:
+        if self._daemon_mode:
+            self._trcc.led.set_week_start(self._led_idx, is_sun)
+            return
         self._led.update_week_start(is_sun)
 
     def _on_disk_index_changed(self, idx: int) -> None:
+        if self._daemon_mode:
+            self._trcc.led.set_disk_index(self._led_idx, idx)
+            return
         self._led.update_disk_index(idx)
 
     def _on_memory_ratio_changed(self, ratio: int) -> None:
+        if self._daemon_mode:
+            self._trcc.led.set_memory_ratio(self._led_idx, ratio)
+            return
         self._led.update_memory_ratio(ratio)
 
     def _on_test_mode_changed(self, on: bool) -> None:
+        if self._daemon_mode:
+            self._trcc.led.set_test_mode(self._led_idx, on)
+            return
         self._led.update_test_mode(on)

--- a/src/trcc/ui/gui/trcc_app.py
+++ b/src/trcc/ui/gui/trcc_app.py
@@ -281,9 +281,16 @@ class TRCCApp(QMainWindow):
         # device lists, and command facades come off it.
         from trcc._boot import trcc as _boot_trcc
 
+        from ...core.trcc_proxy import TrccProxy as _TrccProxy
         from ...services.system import SystemService
         self._trcc = _boot_trcc()
-        sys_svc = self._trcc._system_svc
+        sys_svc = getattr(self._trcc, '_system_svc', None)
+        if sys_svc is None and isinstance(self._trcc, _TrccProxy):
+            # Daemon mode: TrccProxy has no _system_svc; build one locally
+            # so the GPU panel / system-info dashboard work in the GUI process.
+            from ...adapters.system import PlatformFactory
+            from ...core.builder import ControllerBuilder
+            sys_svc = ControllerBuilder(PlatformFactory.current()).build_system()
         if sys_svc is None:
             raise RuntimeError(
                 "TRCCApp: SystemService missing on Trcc — "
@@ -436,6 +443,48 @@ class TRCCApp(QMainWindow):
             if path != target and isinstance(handler, LCDHandler):
                 log.info("_rebuild_all_handlers: restoring inactive LCD %s", path)
                 handler.restore_inactive_state()
+
+    def populate_from_descriptors(self) -> None:
+        """Build handlers from IPC descriptors — used in daemon mode (10C.6).
+
+        Fetches LED device descriptors over the IPC socket and creates
+        LEDHandlers in daemon-proxy mode instead of from live device objects.
+        """
+        for handler in list(self._handlers.values()):
+            handler.cleanup()
+        self._handlers.clear()
+        self._active_path = ''
+
+        try:
+            led_descs = self._trcc.led_descriptors()
+        except Exception:
+            log.exception("populate_from_descriptors: led_descriptors() failed")
+            led_descs = []
+
+        for idx, desc in enumerate(led_descs):
+            path = desc.path
+            if path not in self._handlers:
+                handler = LEDHandler(
+                    None, self.uc_led_control, self._on_temp_unit_changed,
+                    trcc=self._trcc, led_idx=idx, descriptor=desc,
+                )
+                self._handlers[path] = handler
+                log.info("LED daemon handler added: %s", path)
+
+        self._refresh_sidebar()
+
+        last_idx = Settings.get_last_device()
+        target = next(
+            (p for p, h in self._handlers.items()
+             if h.device_info and h.device_info.device_index == last_idx),
+            None,
+        )
+        if target is None:
+            target = next(iter(self._handlers), None)
+        if target:
+            self._activate_device(target)
+        else:
+            log.warning("populate_from_descriptors: no devices found from daemon")
 
     def _add_handler(self, device: Any) -> None:
         """Create handler for one new device."""


### PR DESCRIPTION
## Summary

Fixes all LCD control crashes in daemon mode. When `TRCC_DAEMON=1`, the GUI uses `TrccProxy` for IPC — but `_result_from_dict` strips responses to bare `OpResult`, dropping subclass fields like `.frame.native`. Every LCD handler branch that accessed `.frame.native` raised `AttributeError`.

Changes:
- **Theme selection** — routes through `self._app.lcd.load_theme()` IPC call; reads overlay config locally
- **Split mode** — sets `image = None` instead of reading `r.frame.native`
- **Apply mask** — adds `Path(path)` cast (IPC wire delivers `str`, not `Path`); sets `image = None`; adds `_publish_frame` call so LCD screen updates
- **Fit mode** — sets `image = None`; adds `_publish_frame` call
- **Brightness** — sets `image = None`
- **Rotation** — sets `image = None`
- **Restore last theme** — daemon branch calls `lcd.restore_last_theme()` over IPC; reads overlay from local config

> **Part 2 of 3** — builds on fix/daemon-core (#163). Merge in order.

## Test plan

- [ ] Clicking a theme in the GUI applies it visually (LCD screen updates, preview shows)
- [ ] Mask apply does not crash; LCD screen shows mask
- [ ] Fit mode toggle (fill/fit) applies without exception
- [ ] Brightness slider sends brightness change to device
- [ ] Rotation button changes orientation without crash

---

If this project helps you, consider [buying me a beer](https://buymeacoffee.com/Lexonight1) 🍺 or [Ko-fi](https://ko-fi.com/lexonight1) ☕