### PR TITLE
Fix desktop entry, --version flag, and install UX

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ MODPROBE_CONF="/etc/modprobe.d/trcc-lcd.conf"
 # Resolve real user when running under sudo
 REAL_USER="${SUDO_USER:-$USER}"
 REAL_HOME="$(getent passwd "$REAL_USER" | cut -d: -f6)"
-DESKTOP_FILE="$REAL_HOME/.local/share/applications/trcc.desktop"
+DESKTOP_FILE="$REAL_HOME/.local/share/applications/trcc-linux.desktop"
 AUTOSTART_FILE="$REAL_HOME/.config/autostart/trcc.desktop"
 CONFIG_DIR="$REAL_HOME/.trcc"
 USER_CONTENT_DIR="$REAL_HOME/.trcc-user"
@@ -189,7 +189,7 @@ install_trcc() {
     fi
 
     info "Installing TRCC via pip..."
-    if sudo -u "$REAL_USER" pip install --break-system-packages -e "$SCRIPT_DIR" 2>/dev/null; then
+    if sudo -u "$REAL_USER" pip install --quiet --break-system-packages -e "$SCRIPT_DIR" 2>/dev/null; then
         info "pip install succeeded."
     else
         warn "pip refused direct install — using virtual environment instead."
@@ -214,13 +214,14 @@ install_trcc_venv() {
         sudo -u "$REAL_USER" python3 -m venv "$VENV_DIR"
     fi
 
-    sudo -u "$REAL_USER" "$VENV_DIR/bin/pip" install -e "$SCRIPT_DIR"
+    sudo -u "$REAL_USER" "$VENV_DIR/bin/pip" install --quiet -e "$SCRIPT_DIR"
     info "Installed in venv: $VENV_DIR"
 }
 
 check_trcc_on_path() {
-    if command -v trcc &>/dev/null; then
-        info "trcc $(trcc --version 2>/dev/null || echo '') is ready."
+    # Check the REAL user's PATH (not root's) since the script runs via sudo.
+    if sudo -u "$REAL_USER" bash -lc 'command -v trcc' &>/dev/null; then
+        info "trcc $(sudo -u "$REAL_USER" bash -lc 'trcc --version') is ready."
         return
     fi
 
@@ -247,6 +248,79 @@ find_trcc_cmd() {
     fi
 }
 
+# ── Package Manager Detection ─────────────────────────────────────────────
+
+detect_package_install() {
+    if command -v rpm &>/dev/null && rpm -q trcc-linux &>/dev/null; then
+        echo "rpm"
+        return
+    fi
+    if command -v dpkg &>/dev/null && dpkg -l trcc-linux 2>/dev/null | grep -q '^ii'; then
+        echo "deb"
+        return
+    fi
+    if command -v pacman &>/dev/null && pacman -Q trcc-linux &>/dev/null; then
+        echo "arch"
+        return
+    fi
+    echo ""
+}
+
+remove_package_install() {
+    local pkg_type="$1"
+    case "$pkg_type" in
+        rpm)
+            if command -v dnf &>/dev/null; then
+                dnf remove -y trcc-linux
+            elif command -v yum &>/dev/null; then
+                yum remove -y trcc-linux
+            else
+                rpm -e trcc-linux
+            fi
+            ;;
+        deb)
+            if command -v apt-get &>/dev/null; then
+                apt-get remove -y trcc-linux
+            elif command -v apt &>/dev/null; then
+                apt remove -y trcc-linux
+            else
+                dpkg -r trcc-linux
+            fi
+            ;;
+        arch)
+            if command -v pacman &>/dev/null; then
+                pacman -R --noconfirm trcc-linux
+            fi
+            ;;
+    esac
+}
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+_is_trcc_installed() {
+    # Returns 0 if all system setup artifacts exist (i.e. a previous install
+    # already wrote udev rules, modprobe conf, and modules-load).
+    if ! sudo -u "$REAL_USER" bash -lc 'command -v trcc' &>/dev/null; then
+        return 1
+    fi
+    [ -f /etc/udev/rules.d/99-trcc-lcd.rules ] || return 1
+    [ -f /etc/modprobe.d/trcc-lcd.conf ] || return 1
+    [ -f /etc/modules-load.d/trcc-sg.conf ] || return 1
+    return 0
+}
+
+_copy_desktop_entry() {
+    local desktop_src="$SCRIPT_DIR/trcc-linux.desktop"
+    if [ -f "$desktop_src" ]; then
+        sudo -u "$REAL_USER" mkdir -p "$REAL_HOME/.local/share/applications"
+        sudo -u "$REAL_USER" cp "$desktop_src" "$DESKTOP_FILE"
+        chmod 644 "$DESKTOP_FILE"
+        info "Installed app launcher: $DESKTOP_FILE"
+    else
+        warn "Desktop entry source not found: $desktop_src"
+    fi
+}
+
 # ── Install Orchestrator ──────────────────────────────────────────────────
 
 do_install() {
@@ -257,6 +331,18 @@ do_install() {
     check_repo_root
     check_root
 
+    local pkg_install
+    pkg_install="$(detect_package_install)"
+    if [ -n "$pkg_install" ]; then
+        warn "Detected trcc-linux installed via $pkg_install package manager."
+        if ask_yn "Remove the package-managed install before continuing?"; then
+            remove_package_install "$pkg_install"
+        else
+            warn "Continuing anyway - you may have conflicting binaries and files."
+        fi
+        echo ""
+    fi
+
     step "1/3" "Checking Python & pip..."
     check_python
     detect_immutable
@@ -265,45 +351,85 @@ do_install() {
     fi
     ensure_pip
 
-    step "2/3" "Installing TRCC Python package..."
-    install_trcc
-
-    step "3/3" "Running setup wizard (deps, udev, desktop entry)..."
-    local trcc_cmd
-    trcc_cmd="$(find_trcc_cmd)"
-    info "Running: $trcc_cmd setup --yes"
-    # trcc setup handles: system deps, GPU drivers, udev, SELinux, desktop entry.
-    # Run as the real user so the user's site-packages / venv are importable —
-    # if run as root, ~/.local installs aren't on sys.path and `trcc` crashes.
-    if [[ "$trcc_cmd" == PYTHONPATH=* ]]; then
-        sudo -u "$REAL_USER" -H bash -lc \
-            "PATH=\"$REAL_HOME/.local/bin:$VENV_DIR/bin:\$PATH\" $trcc_cmd setup --yes"
-    else
-        sudo -u "$REAL_USER" -H env \
-            PATH="$REAL_HOME/.local/bin:$VENV_DIR/bin:$PATH" \
-            "$trcc_cmd" setup --yes
+    # Early update detection so step headers reflect reality
+    local mode="installed"
+    if _is_trcc_installed; then
+        mode="updated"
     fi
 
-    print_success
+    if [ "$mode" = "updated" ]; then
+        step "2/3" "Refreshing TRCC Python package..."
+    else
+        step "2/3" "Installing TRCC Python package..."
+    fi
+    install_trcc
+
+    # Step 3: system setup (fresh install) or update path
+    if [ "$mode" = "updated" ]; then
+        info "TRCC already installed - running update..."
+        step "3/3" "Refreshing system files..."
+    else
+        step "3/3" "Running setup wizard (deps, udev)..."
+        local trcc_cmd py_ver site_paths
+        trcc_cmd="$(find_trcc_cmd)"
+
+        # We are already root (check_root passed), but trcc is installed in the
+        # real user's ~/.local.  Preserve the user's site-packages on PYTHONPATH
+        # so the root process can still import trcc while writing system udev rules.
+        py_ver="$(sudo -u "$REAL_USER" python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+        site_paths="$REAL_HOME/.local/lib/python${py_ver}/site-packages"
+        if [ -d "$VENV_DIR/lib/python${py_ver}/site-packages" ]; then
+            site_paths="$VENV_DIR/lib/python${py_ver}/site-packages:$site_paths"
+        fi
+
+        info "Running: $trcc_cmd system setup"
+        if [[ "$trcc_cmd" == PYTHONPATH=* ]]; then
+            eval "$trcc_cmd system setup"
+        else
+            PYTHONPATH="$site_paths:$SCRIPT_DIR/src" "$trcc_cmd" system setup
+        fi
+    fi
+
+    _copy_desktop_entry
+    print_success "$mode"
 }
 
 print_success() {
+    local mode="${1:-installed}"
     echo ""
-    echo -e "${GREEN}${BOLD}=== TRCC Linux v${TRCC_VERSION} installed ===${RESET}"
-    echo ""
-    echo "Next steps:"
-    echo "  1. Unplug and replug the USB cable (or reboot)"
-    if [ "$USE_VENV" = true ]; then
-        echo "  2. source $VENV_DIR/bin/activate"
-        echo "  3. trcc gui"
+    if [ "$mode" = "updated" ]; then
+        echo -e "${GREEN}${BOLD}=== TRCC Linux v${TRCC_VERSION} updated ===${RESET}"
     else
-        echo "  2. trcc gui"
+        echo -e "${GREEN}${BOLD}=== TRCC Linux v${TRCC_VERSION} installed ===${RESET}"
     fi
     echo ""
+    echo "Quick start:"
+    if [ "$mode" != "updated" ]; then
+        echo "  1. Unplug and replug the USB cable (or reboot)"
+    fi
+    if [ "$USE_VENV" = true ]; then
+        echo "  $([[ "$mode" == "updated" ]] && echo "1" || echo "2"). source $VENV_DIR/bin/activate"
+        echo "  $([[ "$mode" == "updated" ]] && echo "2" || echo "3"). trcc gui                          # launch from terminal"
+    else
+        echo "  $([[ "$mode" == "updated" ]] && echo "1" || echo "2"). trcc gui                          # launch from terminal"
+    fi
+    echo "     # or find 'TRCC Linux' in your app launcher"
+    echo ""
+    echo "Desktop entry:"
+    echo "  App launcher item updated at:"
+    echo "    $DESKTOP_FILE"
+    echo "  If it doesn't appear immediately, refresh your menu:"
+    echo "    update-desktop-database ~/.local/share/applications/   # most DEs"
+    echo "    kbuildsycoca5 --noincremental                            # KDE Plasma"
+    echo "    # or log out and back in (works everywhere)"
+    echo ""
+    echo "Autostart (optional):"
+    echo "  trcc system autostart enable          # launch on login"
+    echo ""
     echo "Troubleshooting:"
-    echo "  trcc detect       # check if device is found"
-    echo "  trcc detect --all # show all devices"
-    echo "  trcc test         # color cycle test"
+    echo "  trcc detect         # check if device is found"
+    echo "  trcc detect --all   # show all devices"
+    echo "  trcc test           # color cycle test"
     echo ""
     echo "Full guide: doc/GUIDE_INSTALL.md"
 }
@@ -317,6 +443,19 @@ do_uninstall() {
     check_bash_version
 
     local removed=0
+
+    # 0. Package manager uninstall
+    local pkg_install
+    pkg_install="$(detect_package_install)"
+    if [ -n "$pkg_install" ]; then
+        if [ "$(id -u)" -eq 0 ]; then
+            info "Removing package-managed install ($pkg_install)..."
+            remove_package_install "$pkg_install"
+            removed=1
+        else
+            warn "Detected $pkg_install install - run with sudo to remove it."
+        fi
+    fi
 
     # 1. pip uninstall
     info "Removing TRCC Python package..."

--- a/src/trcc/_entry.py
+++ b/src/trcc/_entry.py
@@ -13,5 +13,10 @@ from __future__ import annotations
 
 def main() -> int | None:
     """Dispatch to the new top-level CLI."""
+    import sys
+    if "--version" in sys.argv or "-v" in sys.argv:
+        from trcc import __version__
+        print(__version__)
+        return 0
     from trcc.ui.cli.main import main as _next_main
     return _next_main()

--- a/src/trcc/adapters/system/linux.py
+++ b/src/trcc/adapters/system/linux.py
@@ -398,6 +398,46 @@ class LinuxScsiTransport(ScsiTransport):
         return (cdb_buf, data_buf, sense_buf, hdr, ioctl_buf)
 
 
+def _install_desktop_entry() -> int:
+    """Copy the bundled .desktop file into the user's applications directory.
+
+    Uses ``importlib.resources`` to locate ``trcc/assets/trcc-linux.desktop``
+    so the file is discoverable whether trcc was installed via pip, source, or
+    a frozen bundle. Falls back silently if the resource is not found (e.g.
+    an un-packaged dev checkout).
+    """
+    # XDG app launchers are per-user - root never needs one, and
+    # install.sh already copies the .desktop for the real user.
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        log.debug("_install_desktop_entry: running as root - skipping")
+        return 0
+
+    try:
+        from importlib.resources import files  # type: ignore[attr-defined]
+    except ImportError:  # pragma: no cover (Python < 3.9)
+        log.debug("_install_desktop_entry: importlib.resources.files unavailable")
+        return 0
+
+    try:
+        ref = files("trcc.assets") / "trcc-linux.desktop"
+        if not ref.is_file():
+            log.debug(
+                "_install_desktop_entry: trcc/assets/trcc-linux.desktop not found"
+            )
+            return 0
+
+        desktop_dir = Path.home() / ".local" / "share" / "applications"
+        desktop_dir.mkdir(parents=True, exist_ok=True)
+        dest = desktop_dir / "trcc-linux.desktop"
+        dest.write_bytes(ref.read_bytes())
+        dest.chmod(0o644)
+        log.info("_install_desktop_entry: installed %s", dest)
+        return 0
+    except Exception as e:
+        log.warning("_install_desktop_entry: failed - %s", e)
+        return 1
+
+
 # =========================================================================
 # LinuxPlatform
 # =========================================================================
@@ -509,12 +549,15 @@ class LinuxPlatform(Platform):
     def setup(self, interactive: bool = True) -> int:
         """Run one-time Linux setup.
 
-        Two things happen here and neither can silently no-op:
-          1. udev rules — write /etc/udev/rules.d/99-trcc-lcd.rules for
+        Three things happen here and none can silently no-op:
+          1. udev rules - write /etc/udev/rules.d/99-trcc-lcd.rules for
              every device in the registry + modprobe quirks + sg autoload.
              Requires root; re-execs via sudo when not already root.
           2. GPU Python extras — detect GPU vendors via PCI sysfs and
              pip install matching libs (e.g., nvidia-ml-py for NVIDIA).
+          3. Desktop entry - copy ``trcc-linux.desktop`` to
+             ``~/.local/share/applications/`` so the app appears in the
+             desktop environment's launcher menu.
 
         Non-interactive mode prints what would be done and returns 0
         without touching the system.
@@ -532,7 +575,8 @@ class LinuxPlatform(Platform):
         vendors = detect_gpu_vendors()
         log.info("Detected GPU vendors: %s", sorted(vendors) or "none")
         rc_gpu = install_matching_gpu_extras(vendors, dry_run=False)
-        return rc_udev or rc_gpu
+        rc_desktop = _install_desktop_entry()
+        return rc_udev or rc_gpu or rc_desktop
 
     def check_permissions(self) -> list[str]:
         """Return user-facing warnings if udev rules are missing, etc."""

--- a/src/trcc/core/commands/system.py
+++ b/src/trcc/core/commands/system.py
@@ -368,8 +368,9 @@ class RunSetup(Command[SetupResult]):
     interactive: bool = True
 
     def execute(self, app: App) -> SetupResult:
-        warnings = app.platform.check_permissions()
+        pre_warnings = app.platform.check_permissions()
         code = app.platform.setup(interactive=self.interactive)
+        warnings = app.platform.check_permissions() if code == 0 else pre_warnings
         return SetupResult(
             ok=code == 0,
             message=f"Setup completed with exit code {code}",


### PR DESCRIPTION
- Fix .desktop filename (trcc.desktop → trcc-linux.desktop)
- Add _install_desktop_entry() in LinuxPlatform for pip installs
- Fix trcc system setup dry-run: remove --yes so udev rules apply
- Fix stale udev warning in RunSetup by re-checking after setup
- Add --version / -v flag to CLI
- Add update path: skip redundant setup on re-run, always refresh pip + .desktop
- Add RPM/DEB/Arch package conflict detection and removal
- Fix root PYTHONPATH for editable installs
- Fix false PATH warning: check real user's PATH via login shell
- Restructure install.sh success output with DE-specific refresh commands
- Added pip --quiet to install/update