### PR TITLE
fix: carry LED segment mask to GUI preview via FrameSent

### DIFF
--- a/src/trcc/core/commands/led.py
+++ b/src/trcc/core/commands/led.py
@@ -320,6 +320,7 @@ class RenderLed(Command[LedColorsResult]):
             # device (LCD carries a surface; LED carries the colors).
             app.events.publish(FrameSent(
                 key=self.key, bytes_sent=len(colors), display_colors=colors,
+                mask=list(mask),
             ))
         return LedColorsResult(
             ok=ok, key=self.key, colors=colors,

--- a/src/trcc/core/events.py
+++ b/src/trcc/core/events.py
@@ -61,6 +61,10 @@ class FrameSent(Event):
     # LCD (one render → FrameSent → handle_frame → preview), not a parallel
     # one.  Empty for LCD / pure-bytes sends.
     display_colors: list = field(default_factory=list)
+    # LED segment mask (list of bool) — determines which LEDs are
+    # lit vs off.  Carried alongside display_colors so the GUI preview
+    # accurately mirrors the physical hardware for segment-display styles.
+    mask: list = field(default_factory=list)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/trcc/ui/gui/led_handler.py
+++ b/src/trcc/ui/gui/led_handler.py
@@ -329,9 +329,10 @@ class LEDHandler(BaseHandler):
     def handle_frame(self, image: Any) -> None:
         """Receive tick result — update LED color display on the panel."""
         display_colors = image.get('display_colors') if isinstance(image, dict) else None
+        display_mask = image.get('mask') if isinstance(image, dict) else None
         log.debug("handle_frame: active=%s colors=%s",
                   self._active, len(display_colors) if display_colors else None)
         if not self._active:
             return
         if display_colors is not None:
-            self._panel.set_led_colors(display_colors)
+            self._panel.set_led_colors(display_colors, display_mask)

--- a/src/trcc/ui/gui/trcc_app.py
+++ b/src/trcc/ui/gui/trcc_app.py
@@ -511,10 +511,11 @@ class TRCCApp(QMainWindow):
         # FrameSent → handle_frame seam (the device's render IS the preview).
         surface = getattr(event, "surface", None)
         colors = getattr(event, "display_colors", None)
+        mask = getattr(event, "mask", None)
         if surface is not None:
             handler.handle_frame(surface)
         elif colors:
-            handler.handle_frame({"display_colors": list(colors)})
+            handler.handle_frame({"display_colors": list(colors), "mask": list(mask) if mask else None})
         else:
             handler.rebuild_preview()
 

--- a/src/trcc/ui/gui/uc_led_control.py
+++ b/src/trcc/ui/gui/uc_led_control.py
@@ -859,9 +859,11 @@ class UCLedControl(QWidget):
         elif is_lf11:
             self._populate_disk_identity()
 
-    def set_led_colors(self, colors: list[tuple[int, int, int]]) -> None:
+    def set_led_colors(self, colors: list[tuple[int, int, int]], mask: list[bool] | None = None) -> None:
         """Update LED preview from controller tick."""
         self._preview.set_colors(colors)
+        if mask is not None:
+            self._preview.set_mask(mask)
 
     def set_status(self, text: str) -> None:
         """Update status text."""

--- a/src/trcc/ui/gui/uc_screen_led.py
+++ b/src/trcc/ui/gui/uc_screen_led.py
@@ -500,6 +500,13 @@ class UCScreenLED(QWidget):
             self._colors.append((0, 0, 0))
         self.update()
 
+    def set_mask(self, mask: list[bool]) -> None:
+        """Update LED on/off mask from controller tick."""
+        self._is_on = list(mask[:len(self._is_on)])
+        while len(self._is_on) < len(self._positions):
+            self._is_on.append(False)
+        self.update()
+
     def set_segment_on(self, index: int, on: bool) -> None:
         """Toggle an individual segment."""
         if 0 <= index < len(self._is_on):
@@ -637,6 +644,8 @@ class UCScreenLED(QWidget):
         for i, pos in enumerate(self._positions):
             if i >= len(self._colors):
                 break
+            if i < len(self._is_on) and not self._is_on[i]:
+                continue
             r, g, b = self._colors[i]
             if r == 0 and g == 0 and b == 0:
                 continue


### PR DESCRIPTION
## Problem

The GUI simulated LED segment display was showing all segments lit regardless of mode. This happened because `FrameSent` only carried `display_colors` but not the `mask` (on/off boolean list) computed by `compute_mask()`. For segment-display styles like `TEMP_LINKED`, `LOAD_LINKED`, etc., the preview would show all segments illuminated even though only specific segments should be lit.

## Fix

- Add `mask: list` field to `FrameSent` event (default empty, backward compatible)
- Pass `mask` from `RenderLed.execute()` when publishing `FrameSent`
- Wire mask through `TRCCApp._on_bus_frame_sent` → `LEDHandler.handle_frame`
- Add optional `mask` parameter to `UCLedControl.set_led_colors()`
- Add `UCScreenLED.set_mask()` to update on/off state per tick
- Check `_is_on` in `_paint_led_rects()` so masked-off segments stay dim (grey underlay only)

## Files changed

- `src/trcc/core/events.py` — add mask field
- `src/trcc/core/commands/led.py` — publish mask with FrameSent
- `src/trcc/ui/gui/trcc_app.py` — bridge mask from event
- `src/trcc/ui/gui/led_handler.py` — extract and forward mask
- `src/trcc/ui/gui/uc_led_control.py` — accept optional mask
- `src/trcc/ui/gui/uc_screen_led.py` — set_mask() + render check

## Testing

Tested on **macOS 26.6 (Intel x86_64)** with PA120 Digital (0416:8001):
- TEMP_LINKED mode now shows only temperature-digit segments lit
- Other modes (COLORFUL, BREATHING, etc.) unaffected
- No regression on LCD FrameSent path (mask default empty)