### PR TITLE
fix(cli): self-connect before sending in display color/test (#150)

### DIFF
--- a/src/trcc/ui/cli/display.py
+++ b/src/trcc/ui/cli/display.py
@@ -110,7 +110,15 @@ def color(
                    "(expected 6 hex chars, e.g. ff0000)", err=True)
         raise typer.Exit(code=2)
     r, g, b = rgb
-    result = get_app().dispatch(SendColor(key=key, r=r, g=g, b=b))
+    app_obj = get_app()
+    # Each CLI invocation is a fresh App (non-daemon) with no attached devices,
+    # so connect before sending — ConnectDevice is idempotent, so this is a
+    # no-op when a daemon/GUI already holds the device. (#150)
+    conn = app_obj.dispatch(ConnectDevice(key=key))
+    if not conn.ok:
+        typer.echo(conn.message, err=True)
+        raise typer.Exit(code=1)
+    result = app_obj.dispatch(SendColor(key=key, r=r, g=g, b=b))
     typer.echo(result.message)
     if not result.ok:
         raise typer.Exit(code=1)
@@ -901,6 +909,12 @@ def test(
     import time
 
     app_obj = get_app()
+    # Fresh-process App has no attached devices (non-daemon); connect first.
+    # Idempotent, so it's a no-op against a daemon/GUI already streaming. (#150)
+    conn = app_obj.dispatch(ConnectDevice(key=key))
+    if not conn.ok:
+        typer.echo(conn.message, err=True)
+        raise typer.Exit(code=1)
     sequence = (
         ("red",   (0xFF, 0x00, 0x00)),
         ("green", (0x00, 0xFF, 0x00)),

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -187,12 +187,26 @@ def test_display_set_brightness_persists(cli_runner: CliRunner, cli_app) -> None
     assert result.exit_code == 0
 
 
-def test_display_color_without_device(cli_runner: CliRunner, cli_app) -> None:
-    """``display color`` needs a connected device — exits non-zero
-    with a structured "not attached" message."""
+def test_display_color_auto_connects_then_sends(cli_runner: CliRunner, cli_app) -> None:
+    """``display color`` self-connects before sending (#150).
+
+    Each non-daemon CLI invocation is a fresh App with no attached devices,
+    so the command dispatches ConnectDevice first — a known, present device
+    therefore sends successfully without a separate ``device connect`` step.
+    """
     del cli_app
     result = cli_runner.invoke(
         _app(), ["display", "color", "0402:3922", "ff0000"],
+    )
+    assert result.exit_code == 0
+
+
+def test_display_color_unknown_device_fails(cli_runner: CliRunner, cli_app) -> None:
+    """An unknown VID:PID can't connect, so ``display color`` exits non-zero
+    with the connect failure surfaced (not a silent send)."""
+    del cli_app
+    result = cli_runner.invoke(
+        _app(), ["display", "color", "dead:beef", "ff0000"],
     )
     assert result.exit_code != 0
 


### PR DESCRIPTION
## Problem
On a freshly-handshaking LCD, `trcc display color KEY ff0000` (and `display test`) fail with **"Not attached"** even though the device works — `trcc test`/`trcc-test` display fine and `trcc device connect KEY` reports success. (#150)

## Root cause
In non-daemon mode every CLI subcommand is a **fresh process → fresh `App` with an empty `devices` dict**. `display color`/`display test` dispatch `SendColor` cold → `_require_connected_device` → "Not attached". `trcc device connect KEY` does attach+connect, but in a *separate* process whose `App` dies on exit, so the state never reaches the send process. The diagnostic commands in `system.py` (`hid-debug`/`led-debug`) already self-connect; these two just omitted it.

## Fix
`display color` and `display test` dispatch `ConnectDevice(key)` before sending, bailing with the connect message if it fails — the same pattern `system hid-debug` uses. A present device sends standalone; an unknown device surfaces the connect failure.

## Verification
- Real CLI smoke (fresh App, device present but never pre-connected → sends; unknown device → exits non-zero).
- Full suite **2349 passed**; ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)