### PR TITLE
fix(setup): GPU reader install, autosuspend reconnect loop, setup alias (#161, #201, #194)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,7 +353,12 @@ jobs:
           #!/bin/sh
           set -e
           python3 -m venv /opt/trcc-linux
-          /opt/trcc-linux/bin/pip install --quiet "trcc-linux==${VER}"
+          # Bundle nvidia-ml-py in the venv (pure-Python, ~53 KB).  The venv is
+          # isolated + root-owned, so the apt python3-pynvml Recommends is invisible
+          # to it AND the runtime setup pip (run as the unprivileged user) cannot
+          # write here (EACCES).  Bundling makes NVIDIA metrics work out of the box
+          # and the runtime pip then just no-ops as already-satisfied. (#161)
+          /opt/trcc-linux/bin/pip install --quiet "trcc-linux==${VER}" nvidia-ml-py
           for cmd in trcc trcc-gui trcc-lcd; do
             echo "#!/bin/sh" > /usr/bin/\$cmd
             echo "exec /opt/trcc-linux/bin/\$cmd \"\\\$@\"" >> /usr/bin/\$cmd

--- a/packaging/udev/99-trcc-lcd.rules
+++ b/packaging/udev/99-trcc-lcd.rules
@@ -15,8 +15,11 @@
 #      caused the original "USB communication lost" on app exit).
 #      10s = 5x our default 2s metrics-refresh tick → no spurious
 #      suspend during normal use, snappy panel-sleep on close.
-# MUST stay in sync with adapters/system/_udev.py (setup-udev) — same rule,
-# two sources; drifting them re-breaks panel sleep.
+#      EXCEPTION: devices whose firmware re-enumerates under suspend instead of
+#      sleeping (a reconnect loop) pin power/control="on" — see the ChiZhu
+#      GrandVision 360 (87ad:70db / 87cd:70db) below (#201).
+# MUST stay in sync with adapters/system/_udev.py (setup-udev, _NO_AUTOSUSPEND)
+# — same rule, two sources; drifting them re-breaks panel sleep / the loop fix.
 
 # Thermalright LCD Display (SCSI)
 SUBSYSTEM=="scsi_generic", ATTRS{idVendor}=="0402", ATTRS{idProduct}=="3922", MODE="0666"
@@ -55,12 +58,15 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="0418", ATTR{idProduct}=="5304", MODE="0666"
 ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="0418", ATTR{idProduct}=="5304", ATTR{power/control}="auto", ATTR{power/autosuspend_delay_ms}="10000"
 
 # ChiZhu Tech GrandVision 360 AIO (Bulk)
+# power/control="on": this firmware re-enumerates under USB autosuspend instead
+# of sleeping, causing a reconnect loop every ~10-15s — pin it awake (#201).
 SUBSYSTEM=="usb", ATTR{idVendor}=="87ad", ATTR{idProduct}=="70db", MODE="0666"
-ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="87ad", ATTR{idProduct}=="70db", ATTR{power/control}="auto", ATTR{power/autosuspend_delay_ms}="10000"
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="87ad", ATTR{idProduct}=="70db", ATTR{power/control}="on", ATTR{power/autosuspend_delay_ms}="10000"
 
-# Thermalright LCD Display (SCSI)
+# Thermalright LCD Display (SCSI) — ChiZhu GrandVision 360 SCSI sibling, same
+# firmware: pin awake too (#201).
 SUBSYSTEM=="scsi_generic", ATTRS{idVendor}=="87cd", ATTRS{idProduct}=="70db", MODE="0666"
-ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="87cd", ATTR{idProduct}=="70db", ATTR{power/control}="auto", ATTR{power/autosuspend_delay_ms}="10000"
+ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="87cd", ATTR{idProduct}=="70db", ATTR{power/control}="on", ATTR{power/autosuspend_delay_ms}="10000"
 
 # CPU package power (RAPL) — make energy_uj readable without root so trcc can
 # report CPU watts.  energy_uj is root-only since CVE-2020-8694 (PLATYPUS);

--- a/src/trcc/adapters/system/_hotplug.py
+++ b/src/trcc/adapters/system/_hotplug.py
@@ -108,6 +108,13 @@ def _import_dbus_glib() -> tuple[Any, Any] | None:
     log.debug("_import_dbus_glib: called")
     try:
         import dbus  # pyright: ignore[reportMissingImports]
+
+        # NOTE (investigated 2026-06-27): importing gi emits two
+        # DeprecationWarnings on Python 3.14 (GLib.unix_signal_add_full +
+        # asyncio event-loop policy) from PyGObject's OWN internals — not our
+        # calls.  Latest gi (3.56.3) still warns; our 3.12 floor is clean.
+        # Upstream + cosmetic, and this guarded import already degrades
+        # gracefully.  Leave it — don't filter blindly or monkeypatch gi.
         import gi  # noqa: F401  # pyright: ignore[reportMissingImports]
         from dbus.mainloop.glib import (  # pyright: ignore[reportMissingImports]
             DBusGMainLoop,

--- a/src/trcc/adapters/system/_udev.py
+++ b/src/trcc/adapters/system/_udev.py
@@ -17,9 +17,11 @@ Per-wire subsystem mapping:
 Every device also gets `power/control="auto"` +
 `power/autosuspend_delay_ms="10000"` so the kernel autosuspends the device
 ~10s after our frame stream stops; the firmware sleeps the panel in response
-to the USB suspend (the mechanism the Windows app relies on — #143).  This
-MUST match packaging/udev/99-trcc-lcd.rules — the two are the same rule from
-two sources and drifting them re-breaks panel sleep.
+to the USB suspend (the mechanism the Windows app relies on — #143).  The
+EXCEPTION is `_NO_AUTOSUSPEND` devices, whose firmware re-enumerates instead of
+sleeping under suspend (a reconnect loop — #201); they pin `power/control="on"`.
+This MUST match packaging/udev/99-trcc-lcd.rules — the two are the same rule
+from two sources and drifting them re-breaks panel sleep / the loop fix.
 
 For SCSI devices we additionally write /etc/modprobe.d/trcc-lcd.conf
 forcing `usb-storage` Bulk-Only (not UAS) so /dev/sgN is reliably
@@ -71,6 +73,19 @@ _WIRE_SUBSYSTEMS: dict[Wire, tuple[str, ...]] = {
 }
 
 
+# Devices whose firmware can't survive USB autosuspend.  The kernel suspends the
+# port ~10s after our frame stream stops; instead of sleeping the panel, these
+# re-enumerate, the kernel re-suspends ~10s later, and you get a reconnect loop
+# every ~10-15s (#201, em73es' ChiZhu GrandVision 360).  They pin
+# power/control="on" (never autosuspend) instead of the "auto" the other panels
+# use for idle-sleep (#143).  87ad:70db (USB/bulk) is reporter-confirmed;
+# 87cd:70db (its SCSI sibling, same product family) is included by inference.
+_NO_AUTOSUSPEND: frozenset[tuple[int, int]] = frozenset({
+    (0x87ad, 0x70db),
+    (0x87cd, 0x70db),
+})
+
+
 # ── Rule generation ──────────────────────────────────────────────────
 
 
@@ -95,11 +110,12 @@ def build_udev_rules() -> str:
                 f'{attr}{{idProduct}}=="{pid:04x}", '
                 f'MODE="0666"'
             )
+        control = "on" if (vid, pid) in _NO_AUTOSUSPEND else "auto"
         lines.append(
             f'ACTION=="add", SUBSYSTEM=="usb", '
             f'ATTR{{idVendor}}=="{vid:04x}", '
             f'ATTR{{idProduct}}=="{pid:04x}", '
-            f'ATTR{{power/control}}="auto", '
+            f'ATTR{{power/control}}="{control}", '
             f'ATTR{{power/autosuspend_delay_ms}}="10000"'
         )
         lines.append("")

--- a/src/trcc/ui/cli/main.py
+++ b/src/trcc/ui/cli/main.py
@@ -105,6 +105,18 @@ def quickstart(
             raise typer.Exit(code=1)
 
 
+@app.command("setup")
+def setup(
+    yes: bool = typer.Option(False, "--yes", "-y",
+                             help="Non-interactive (assume yes to prompts)"),
+) -> None:
+    """Alias for ``trcc system setup`` — OS-specific setup (udev rules on
+    Linux, WinUSB guide on Windows).  New users reach for the short form. (#194)
+    """
+    log.info("cli setup (alias → system setup): yes=%s", yes)
+    system.setup(yes=yes)
+
+
 @app.command("qtgui")
 def qtgui() -> None:
     """Launch the Qt-native GUI (clean-slate, layout-driven).

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -962,6 +962,22 @@ def test_system_setup_help(cli_runner: CliRunner, cli_app) -> None:
     assert result.exit_code == 0
 
 
+def test_top_level_setup_alias_delegates_to_system_setup(
+    cli_runner: CliRunner, cli_app,
+) -> None:
+    """``trcc setup`` is a top-level alias for ``trcc system setup`` (#194) —
+    it reaches the same RunSetup path (FakePlatform.setup is a 0 no-op)."""
+    del cli_app
+    result = cli_runner.invoke(_app(), ["setup"])
+    assert result.exit_code == 0
+
+
+def test_top_level_setup_alias_registered() -> None:
+    """The alias is wired on the top-level app, not just the system sub-app."""
+    names = {cmd.name for cmd in _app().registered_commands}
+    assert "setup" in names
+
+
 # =========================================================================
 # config sub-app — 4 commands
 # =========================================================================

--- a/tests/test_udev.py
+++ b/tests/test_udev.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from trcc.adapters.system._udev import (
+    _NO_AUTOSUSPEND,
     _WIRE_SUBSYSTEMS,
     build_modprobe_conf,
     build_udev_rules,
@@ -20,15 +21,38 @@ def test_packaged_rule_matches_generated_autosuspend_policy() -> None:
     """The hand-maintained packaged rule and the setup-udev generator are the
     same rule from two sources — they MUST agree on the autosuspend policy or
     panel-sleep silently re-breaks for one install path (#143).  Every add line
-    in the packaged file carries control="auto" + the 10s delay, and the old
+    carries the 10s delay + control="auto" (idle-sleep), EXCEPT _NO_AUTOSUSPEND
+    devices which pin control="on" (reconnect-loop fix, #201).  The old
     never-suspend pin is gone."""
     text = _PACKAGED_RULE.read_text()
     assert 'power/autosuspend}="-1"' not in text
     add_lines = [ln for ln in text.splitlines() if ln.startswith('ACTION=="add"')]
     assert add_lines, "packaged rule has no ACTION==add lines"
     for ln in add_lines:
-        assert 'ATTR{power/control}="auto"' in ln, ln
+        assert ('ATTR{power/control}="auto"' in ln
+                or 'ATTR{power/control}="on"' in ln), ln
         assert 'ATTR{power/autosuspend_delay_ms}="10000"' in ln, ln
+
+
+def test_no_autosuspend_devices_pin_control_on_both_sources() -> None:
+    """Devices that re-enumerate under suspend (#201) MUST pin control="on" in
+    BOTH the generator and the packaged rule — and must NOT carry the "auto"
+    that would re-trigger the reconnect loop."""
+    generated = build_udev_rules()
+    packaged = _PACKAGED_RULE.read_text()
+    assert _NO_AUTOSUSPEND, "expected at least one opt-out device"
+    for vid, pid in _NO_AUTOSUSPEND:
+        on_line = (
+            f'ACTION=="add", SUBSYSTEM=="usb", '
+            f'ATTR{{idVendor}}=="{vid:04x}", '
+            f'ATTR{{idProduct}}=="{pid:04x}", '
+            f'ATTR{{power/control}}="on", '
+            f'ATTR{{power/autosuspend_delay_ms}}="10000"'
+        )
+        auto_line = on_line.replace('"on"', '"auto"')
+        for src_name, src in (("generated", generated), ("packaged", packaged)):
+            assert on_line in src, f"{vid:04x}:{pid:04x} not pinned on in {src_name}"
+            assert auto_line not in src, f"{vid:04x}:{pid:04x} still auto in {src_name}"
 
 
 _POWERCAP_RULE = (
@@ -51,9 +75,10 @@ def test_packaged_rule_matches_generated_rapl_grant() -> None:
 
 
 def test_every_registered_device_enables_autosuspend() -> None:
-    """Every device gets control="auto" + a 10s delay so the kernel can
-    autosuspend it and the firmware sleeps the panel.  Must NOT carry the old
-    power/autosuspend="-1" never-suspend pin, which kept panels lit and
+    """Every device gets a 10s delay + control="auto" so the kernel can
+    autosuspend it and the firmware sleeps the panel — EXCEPT _NO_AUTOSUSPEND
+    devices, which pin control="on" (reconnect-loop fix, #201).  Must NOT carry
+    the old power/autosuspend="-1" never-suspend pin, which kept panels lit and
     re-broke setup-udev for ErP users (#143)."""
     rules = build_udev_rules()
 
@@ -63,11 +88,12 @@ def test_every_registered_device_enables_autosuspend() -> None:
     for (vid, pid), product in ALL_DEVICES.items():
         vid_str = f"{vid:04x}"
         pid_str = f"{pid:04x}"
+        control = "on" if (vid, pid) in _NO_AUTOSUSPEND else "auto"
         expected = (
             f'ACTION=="add", SUBSYSTEM=="usb", '
             f'ATTR{{idVendor}}=="{vid_str}", '
             f'ATTR{{idProduct}}=="{pid_str}", '
-            f'ATTR{{power/control}}="auto", '
+            f'ATTR{{power/control}}="{control}", '
             f'ATTR{{power/autosuspend_delay_ms}}="10000"'
         )
         assert expected in rules, (


### PR DESCRIPTION
Three setup/packaging fixes (each its own commit) plus a lint fix.

## #161 — GPU reader never installs on the legacy `.deb` (no GPU metrics)
The `legacy_all` `.deb` installs into an isolated, root-owned venv at `/opt/trcc-linux`. apt's `Recommends: python3-pynvml` lands in system `dist-packages` (invisible to that venv), and `trcc system setup`'s runtime `pip install nvidia-ml-py` runs as the unprivileged user against the root-owned venv → `Permission denied: .../site-packages/example.py`. The reader never installed (e.g. no readings on a 5080).
**Fix:** bundle `nvidia-ml-py` (pure-Python, ~53 KB) into the venv at build time. NVIDIA users get metrics out of the box and the runtime setup pip no-ops "already satisfied". Standard deb / RPM / Nix already covered it.

## #201 — ChiZhu GrandVision 360 reconnect loop every ~10–15s
`power/control="auto"` (added for #143 idle panel-sleep) makes the `87ad:70db` firmware **re-enumerate** instead of sleeping under USB autosuspend, so the kernel re-suspends it → reconnect loop. The loop is pure kernel+firmware (the app subscribes to `DeviceAttached` only, never `DeviceDetached`, and `_on_device_attached` is guarded — it does not amplify), so the udev power policy is the lever.
**Fix:** a `_NO_AUTOSUSPEND` opt-out — `87ad:70db` + `87cd:70db` pin `power/control="on"`; every other device keeps `"auto"`, so #143's idle-sleep is preserved. Mirrored in the packaged rule (kept in sync). `87ad:70db` is reporter-confirmed; `87cd:70db` is the same product family, by inference.

## #194 — `trcc setup` was not a command
Only `trcc system setup` existed. Added a thin top-level `setup` alias delegating to the same body.

## Verification
- Generator output confirmed (`0402`→auto, `87ad`/`87cd`→on); generated and packaged rules kept in sync.
- `trcc setup` resolves + delegates (tests).
- Full suite **2351 passed / 4 skipped**; `ruff check .` (full repo) + pyright clean.

### Hardware-gated confirmation owed
- **#161** — next `.deb` build; reporter verifies the 5080 appears.
- **#201** — reporter (em73es) confirms the loop is gone and the panel still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)