### PR TITLE
fix(theme): save background, theme-name precedence, formats + universal listing/delete

### DIFF
--- a/src/trcc/core/commands/_helpers.py
+++ b/src/trcc/core/commands/_helpers.py
@@ -229,6 +229,11 @@ def _require_connected_device(app: App, key: str) -> Any:
     log.debug("_require_connected_device: key=%s", key)
     device = app.get(key)
     if not device.is_connected:
+        # DeviceNotConnectedError propagates PAST App.dispatch (no try/except
+        # there), so without this the rejected wire command is invisible in the
+        # log.  Warn with the key — the universal "acted before connect" trace.
+        log.warning("%s: wire command dispatched before ConnectDevice — "
+                    "device attached but not connected", key)
         raise DeviceNotConnectedError(
             f"{key} not connected — dispatch ConnectDevice first"
         )

--- a/src/trcc/core/commands/device.py
+++ b/src/trcc/core/commands/device.py
@@ -980,6 +980,8 @@ class UploadBootAnimation(Command[BootAnimationResult]):
                 message=f"{self.key} is not a SCSI LCD (boot animation is SCSI-only)",
             )
         if not device.is_connected:
+            log.warning("UploadBootAnimation %s: device not connected — "
+                        "dispatched before ConnectDevice", self.key)
             raise DeviceNotConnectedError(
                 f"{self.key} not connected — dispatch ConnectDevice first"
             )
@@ -1088,7 +1090,7 @@ class SetBrightness(Command[BrightnessResult]):
         if not 0 <= self.percent <= 100:
             return BrightnessResult(
                 ok=False, key=self.key, percent=self.percent,
-                message="Brightness out of range (0–100)",
+                message=f"Brightness out of range (0–100): {self.percent}",
             )
         app.settings.set_brightness(self.key, self.percent)
         _invalidate_scene(app, self.key)

--- a/src/trcc/core/commands/led.py
+++ b/src/trcc/core/commands/led.py
@@ -73,6 +73,8 @@ class SetLedColors(Command[LedColorsResult]):
                 message=f"{self.key} is not an LED device",
             )
         if not device.is_connected:
+            log.warning("SetLedColors %s: device not connected — "
+                        "dispatched before ConnectDevice", self.key)
             raise DeviceNotConnectedError(
                 f"{self.key} not connected — dispatch ConnectDevice first"
             )
@@ -184,6 +186,10 @@ class RenderLed(Command[LedColorsResult]):
                 message=f"{self.key} is not an LED device",
             )
         if not device.is_connected:
+            # Per-frame command (DEBUG) — not-connected here is a transient
+            # race with disconnect, not a user mis-step; keep it off INFO.
+            log.debug("RenderLed %s: device not connected — skipping frame",
+                      self.key)
             raise DeviceNotConnectedError(
                 f"{self.key} not connected — dispatch ConnectDevice first"
             )

--- a/src/trcc/core/commands/theme.py
+++ b/src/trcc/core/commands/theme.py
@@ -81,6 +81,38 @@ def _theme_preview(theme_dir: Path) -> str:
     return str(any_png) if any_png is not None else ""
 
 
+_THEME_MARKERS = ("trcc.json", "config1.dc", "config.json")
+
+
+def _prefer_user_theme(app: App, candidate: Path) -> Path:
+    """Apply the user-wins precedence (the same domain rule as ListThemes) to a
+    RESTORE path.
+
+    If *candidate* is a SHIPPED theme (under ``data_dir``) that a same-named USER
+    theme shadows — the same relative path under ``user_data_dir`` carrying a
+    theme marker — return the user equivalent so a stale program-path pointer
+    self-heals on the next launch.  Otherwise return *candidate* unchanged.
+
+    Restore-only by design: NOT applied to runtime rotation (which shares
+    ``oriented_theme_path``), so rotating a device never surprise-swaps the
+    theme — only a fresh restore re-resolves which theme a name means.  Pure
+    path mapping, so it also covers the no-device restore path. (#theme-collision)
+    """
+    paths = app.platform.paths()
+    data_root = paths.data_dir().resolve()
+    cand = candidate.resolve()
+    if not cand.is_relative_to(data_root):
+        return candidate   # user-saved or external path — keep as stored
+    user_equiv = paths.user_data_dir() / cand.relative_to(data_root)
+    if user_equiv.is_dir() and any(
+        (user_equiv / m).exists() for m in _THEME_MARKERS
+    ):
+        log.info("RestoreLastTheme: shipped theme %s shadowed by user theme %s "
+                 "— restoring the user theme (user-wins)", candidate, user_equiv)
+        return user_equiv
+    return candidate
+
+
 @dataclass(frozen=True, slots=True)
 class LoadTheme(Command[ThemeResult]):
     """Parse a theme, persist it, render the first frame, and send it.
@@ -1117,10 +1149,10 @@ class ListThemes(Command[ThemesListResult]):
     directory: Path | None = None
 
     def execute(self, app: App) -> ThemesListResult:
+        paths = app.platform.paths()
         if self.directory is not None:
             roots = [self.directory]
         elif self.resolution is not None:
-            paths = app.platform.paths()
             w, h = self.resolution
             # User dir FIRST so a user-saved theme WINS over a shipped theme of
             # the same name (dedupe by name below) — a saved "Theme1" shadows
@@ -1134,6 +1166,9 @@ class ListThemes(Command[ThemesListResult]):
                 message="ListThemes requires resolution=(w,h) or directory=...",
             )
 
+        # Origin is location-derived (theme under user_data_dir → "user"), so
+        # it is correct in directory mode too and replaces name heuristics.
+        user_root = paths.user_data_dir().resolve()
         seen_names: set[str] = set()
         entries: list[ThemeListEntry] = []
         for root in roots:
@@ -1143,10 +1178,12 @@ class ListThemes(Command[ThemesListResult]):
                              "user theme — skipping", theme.name, root)
                     continue
                 seen_names.add(theme.name)
+                is_user = theme.path.resolve().is_relative_to(user_root)
                 entries.append(ThemeListEntry(
                     name=theme.name, resolution=theme.resolution,
                     path=str(theme.path),
                     preview=str(_theme_preview(theme.path)),
+                    origin="user" if is_user else "shipped",
                 ))
         target_str = "; ".join(str(r) for r in roots)
         return ThemesListResult(
@@ -1459,6 +1496,10 @@ class RestoreLastTheme(Command[ThemeResult]):
         candidate = Path(stored)
         if candidate.is_dir():
             candidate = oriented_theme_path(app, self.key, candidate)
+            # User-wins precedence on restore: a stale pointer at a shipped
+            # theme that a same-named user theme now shadows re-resolves to the
+            # user one (consistent with ListThemes). (#theme-collision)
+            candidate = _prefer_user_theme(app, candidate)
             return LoadTheme(
                 key=self.key, path=candidate, reset_overrides=False,
             ).execute(app)

--- a/src/trcc/core/commands/theme.py
+++ b/src/trcc/core/commands/theme.py
@@ -70,6 +70,17 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+def _theme_preview(theme_dir: Path) -> str:
+    """Tile image for a theme dir: ``Theme.png`` → ``00.png`` → any ``*.png``
+    → ``""``.  Single source for the browser tile so every UI agrees."""
+    for name in ("Theme.png", "00.png"):
+        candidate = theme_dir / name
+        if candidate.is_file():
+            return str(candidate)
+    any_png = next(theme_dir.glob("*.png"), None)
+    return str(any_png) if any_png is not None else ""
+
+
 @dataclass(frozen=True, slots=True)
 class LoadTheme(Command[ThemeResult]):
     """Parse a theme, persist it, render the first frame, and send it.
@@ -413,31 +424,55 @@ class SaveTheme(Command[ThemeResult]):
                 message=f"A theme named {self.name!r} already exists.",
             )
 
+        # Build into a staging dir, THEN atomically swap it over the target.
+        # The theme being saved is usually the target ITSELF (re-saving the
+        # loaded theme — a prior save re-points the active theme at the saved
+        # dir), so deleting the target up-front would destroy the source's own
+        # background/mask BEFORE _build_manifest reads them — the cause of the
+        # "source theme has no background" data loss.  Staging keeps the source
+        # intact until every asset is captured, and makes overwrite crash-safe.
+        staging = target.parent / f".{self.name}.saving"
         try:
             target.parent.mkdir(parents=True, exist_ok=True)
-            if target.exists():
-                log.warning("SaveTheme: overwriting existing theme %s", target)
-                shutil.rmtree(target)
-            target.mkdir(exist_ok=False)
+            if staging.exists():
+                shutil.rmtree(staging)
+            staging.mkdir(exist_ok=False)
         except OSError as e:
-            log.warning("SaveTheme: mkdir failed for %s: %s", target, e)
+            log.warning("SaveTheme: mkdir failed for staging %s: %s", staging, e)
             return ThemeResult(
                 ok=False, key=self.key, theme_name=self.name,
-                message=f"failed to create target directory: {e}",
+                message=f"failed to create staging directory: {e}",
             )
 
         try:
             manifest = self._build_manifest(
-                app, target, theme, device_settings, w, h,
+                app, staging, theme, device_settings, w, h,
             )
-            self._write_manifest(target, manifest)
-            self._write_thumbnail(app, target, theme)
+            self._write_manifest(staging, manifest)
+            self._write_thumbnail(app, staging, theme)
         except (OSError, ThemeError, TrccError) as e:
-            log.exception("SaveTheme: assembly failed; rolling back %s", target)
-            shutil.rmtree(target, ignore_errors=True)
+            log.exception("SaveTheme: assembly failed; discarding staging %s",
+                          staging)
+            shutil.rmtree(staging, ignore_errors=True)
             return ThemeResult(
                 ok=False, key=self.key, theme_name=self.name,
                 message=f"failed to assemble saved theme: {e}",
+            )
+
+        # Swap staging → target.  Every source asset is now captured in staging,
+        # so removing the (possibly ==source) target is safe.
+        try:
+            if target.exists():
+                log.warning("SaveTheme: overwriting existing theme %s", target)
+                shutil.rmtree(target)
+            staging.replace(target)
+        except OSError as e:
+            log.exception("SaveTheme: finalize failed; discarding staging %s",
+                          staging)
+            shutil.rmtree(staging, ignore_errors=True)
+            return ThemeResult(
+                ok=False, key=self.key, theme_name=self.name,
+                message=f"failed to finalize saved theme: {e}",
             )
 
         # Saved theme is now fully self-contained — drop the device's
@@ -561,13 +596,21 @@ class SaveTheme(Command[ThemeResult]):
         width: int,
         height: int,
     ) -> str | None:
-        """Store the resolved current background; return its library ref.
+        """Store the resolved current background; return its manifest ref.
 
-        Image → canonical PNG bytes into the user library (deduped),
-        returning the ref.  Video → bundled verbatim as ``Theme.<ext>``
-        in the theme dir (returns ``None``; videos reload via the in-dir
-        convention).  ``DeviceSettings.background_path`` (cloud override)
-        wins over the source theme's bundled background.
+        Precedence, all returning a ``web/{w}{h}/…`` ref (or ``None``):
+
+        * **Catalog asset** — already under the cloud (``cloud_theme_dir``)
+          or user (``user_background_dir``) ``web/{w}{h}`` tree → REFERENCED
+          by ``web/{w}{h}/<name>``, never copied (cloud/user assets are
+          shared; a re-save re-emits the ref so the bg can't be lost).
+        * **Loose image** → canonical PNG bytes into the user library
+          (deduped), returning the library ref.
+        * **Loose video** → bundled verbatim as ``Theme.<ext>`` in the theme
+          dir (returns ``None``; videos reload via the in-dir convention).
+
+        ``DeviceSettings.background_path`` (cloud/user override) wins over the
+        source theme's bundled background.
         """
         import shutil
 
@@ -578,6 +621,24 @@ class SaveTheme(Command[ThemeResult]):
             log.warning("SaveTheme: source theme %r has no background",
                         theme.name)
             return None
+
+        # Asset already in a data catalog (a cloud download or the user
+        # background library) → REFERENCE it, never copy.  Mirrors
+        # _store_mask's catalog handling + the data-ownership model: cloud /
+        # user ``web/{w}{h}`` assets are shared, not bundled per-theme.  The
+        # ref resolves back via _resolve_asset_ref (user root → cloud root), so
+        # a saved theme just points at the existing download — and a re-save
+        # re-emits the same ref instead of copying, so the background can't be
+        # lost on overwrite. (#bg-save)
+        src_resolved = src.resolve()
+        paths = app.platform.paths()
+        for root in (paths.user_background_dir(width, height),
+                     paths.cloud_theme_dir(width, height)):
+            if src_resolved.is_relative_to(root.resolve()):
+                ref = f"web/{width}{height}/{src.name}"
+                log.info("SaveTheme: background %s is a catalog asset → "
+                         "reference %s (no copy)", src.name, ref)
+                return ref
 
         ext = src.suffix.lower()
         if ext in _VIDEO_EXTS_FOR_SAVE:
@@ -1061,23 +1122,31 @@ class ListThemes(Command[ThemesListResult]):
         elif self.resolution is not None:
             paths = app.platform.paths()
             w, h = self.resolution
-            roots = [paths.theme_dir(w, h), paths.user_theme_dir(w, h)]
+            # User dir FIRST so a user-saved theme WINS over a shipped theme of
+            # the same name (dedupe by name below) — a saved "Theme1" shadows
+            # the placeholder "Theme1", never the reverse.  Universal: every UI
+            # dispatches this Command, so CLI / API / GUI agree on which theme a
+            # name resolves to. (#theme-collision)
+            roots = [paths.user_theme_dir(w, h), paths.theme_dir(w, h)]
         else:
             return ThemesListResult(
                 ok=False, directory="", themes=[],
                 message="ListThemes requires resolution=(w,h) or directory=...",
             )
 
-        seen: set[Path] = set()
+        seen_names: set[str] = set()
         entries: list[ThemeListEntry] = []
         for root in roots:
             for theme in app.themes.list(root):
-                if theme.path in seen:
+                if theme.name in seen_names:
+                    log.info("ListThemes: %r in %s shadowed by a same-named "
+                             "user theme — skipping", theme.name, root)
                     continue
-                seen.add(theme.path)
+                seen_names.add(theme.name)
                 entries.append(ThemeListEntry(
                     name=theme.name, resolution=theme.resolution,
                     path=str(theme.path),
+                    preview=str(_theme_preview(theme.path)),
                 ))
         target_str = "; ".join(str(r) for r in roots)
         return ThemesListResult(

--- a/src/trcc/core/results.py
+++ b/src/trcc/core/results.py
@@ -6,6 +6,7 @@ render.  Every Command has one concrete Result type.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Literal
 
 from .models import (
     DeviceInfo,
@@ -205,16 +206,22 @@ class ThemeImportResult(Result):
 
 @dataclass(frozen=True, slots=True)
 class ThemeListEntry:
-    """One row in a ThemesListResult — name + resolution + path + preview.
+    """One row in a ThemesListResult — name + resolution + path + preview + origin.
 
     ``preview`` is the absolute path to the tile image (``Theme.png`` →
     ``00.png`` → any ``*.png``, else ``""``) so every UI builds the same
     browser tile from the Command result instead of re-walking the dir.
+
+    ``origin`` is the theme's data root — ``"user"`` (saved under
+    ``user_data_dir``) or ``"shipped"`` (pkg / cloud-downloaded).  Location-
+    derived, the canonical replacement for name-based heuristics: it drives the
+    user/default filter and any "my themes" badge, identically in every UI.
     """
     name: str
     resolution: tuple[int, int]
     path: str
     preview: str = ""
+    origin: Literal["user", "shipped"] = "shipped"
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/trcc/core/results.py
+++ b/src/trcc/core/results.py
@@ -205,10 +205,16 @@ class ThemeImportResult(Result):
 
 @dataclass(frozen=True, slots=True)
 class ThemeListEntry:
-    """One row in a ThemesListResult — name + resolution + path."""
+    """One row in a ThemesListResult — name + resolution + path + preview.
+
+    ``preview`` is the absolute path to the tile image (``Theme.png`` →
+    ``00.png`` → any ``*.png``, else ``""``) so every UI builds the same
+    browser tile from the Command result instead of re-walking the dir.
+    """
     name: str
     resolution: tuple[int, int]
     path: str
+    preview: str = ""
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/trcc/services/_clock.py
+++ b/src/trcc/services/_clock.py
@@ -70,6 +70,23 @@ def _translate_date_pattern(pattern: str) -> str:
     return result
 
 
+# The default date format (DeviceSettings.date_format default).  A date element
+# whose pattern renders the same as this is treated as "uncustomised" → the
+# user's global pref wins; a different pattern is a deliberate theme choice.
+_DEFAULT_DATE_FORMAT = "yyyy/MM/dd"
+
+
+def is_default_date_pattern(fmt: str) -> bool:
+    """True if *fmt* (a strftime spec like ``%Y/%m/%d`` OR a ``yyyy/MM/dd``-style
+    pattern) renders identically to the DEFAULT date format.
+
+    The theme reconciliation rule: a date element carrying a NON-default pattern
+    (e.g. ``%m/%d``) is a deliberate design choice the renderer honours; a
+    default-equivalent pattern means the theme didn't customise the date, so the
+    user's global ``date_format`` preference wins — universally, every UI."""
+    return _translate_date_pattern(fmt) == _translate_date_pattern(_DEFAULT_DATE_FORMAT)
+
+
 def resolve_clock(
     source: ClockSource,
     *,

--- a/src/trcc/services/overlay.py
+++ b/src/trcc/services/overlay.py
@@ -18,7 +18,7 @@ from ..core.errors import ThemeError
 from ..core.models import OverlayElement
 from ..core.ports import Renderer
 from . import _dc as Dc
-from ._clock import resolve_clock
+from ._clock import is_default_date_pattern, resolve_clock
 
 log = logging.getLogger(__name__)
 
@@ -330,13 +330,18 @@ class OverlayService:
         source: str = "?",
     ) -> None:
         clock_source = str(element.get("source", ""))
-        # A date element may carry the theme's own strftime pattern (from the
-        # DC, or a grid edit) — honour it instead of the global default.
-        # ``"%" in fmt`` distinguishes a real pattern ("%m/%d") from the
-        # metric default "{value}".  Time/weekday keep the precomputed dict
-        # (localised weekday, 12h handling that isn't a bare strftime).
+        # Date format reconciliation (universal — every UI renders through here):
+        #   * A DELIBERATE non-default theme pattern (e.g. "%m/%d") is honoured —
+        #     a theme designed for a specific date layout keeps it.
+        #   * A default-equivalent pattern ("%Y/%m/%d" ≡ "yyyy/MM/dd") means the
+        #     theme didn't customise the date, so the user's global date_format
+        #     pref wins (it's already baked into the precomputed dict, per
+        #     device).  Time/weekday always use the dict (localised weekday, 12h
+        #     handling).  ``"%" in fmt`` excludes the metric default "{value}".
+        # (#format-prefs)
         elem_fmt = str(element.get("format", ""))
-        if clock_source == "date" and "%" in elem_fmt:
+        if (clock_source == "date" and "%" in elem_fmt
+                and not is_default_date_pattern(elem_fmt)):
             text = resolve_clock("date", date_format=elem_fmt)
         else:
             text = clock.get(clock_source, "")

--- a/src/trcc/ui/gui/lcd_handler.py
+++ b/src/trcc/ui/gui/lcd_handler.py
@@ -26,6 +26,7 @@ from ...core.commands import (
     EnableOverlay,
     ExportTheme,
     ImportTheme,
+    ListThemes,
     LoadCloudTheme,
     LoadTheme,
     RestoreLastTheme,
@@ -542,8 +543,9 @@ class LCDHandler(BaseHandler):
         ))
         self._w['preview'].set_status(r.message)
         if r.ok:
-            # Reload local theme list so the new theme shows up
-            self._w['theme_local'].load_themes()
+            # Re-list via ListThemes so the new theme appears with user-
+            # precedence (same universal path as the initial listing).
+            self._update_theme_directories()
         return r
 
     def export_config(self, path: Path) -> None:
@@ -560,7 +562,7 @@ class LCDHandler(BaseHandler):
         ))
         self._w['preview'].set_status(r.message)
         if r.ok:
-            self._w['theme_local'].load_themes()
+            self._update_theme_directories()   # re-list via ListThemes
 
     # ── DC File Loading ────────────────────────────────────────────
 
@@ -1288,10 +1290,15 @@ class LCDHandler(BaseHandler):
             self._pm.state.is_rotated,
         )
 
-        if theme_dir and theme_dir.exists():
-            self._w['theme_local'].set_theme_directory(theme_dir, user_theme_dir)
-        elif user_theme_dir and user_theme_dir.exists():
-            self._w['theme_local'].set_theme_directory(user_theme_dir)
+        # Local theme browser: dispatch the universal ListThemes Command
+        # (user-precedence + origin + preview) and render its entries — no disk
+        # walk in the View.  The browse resolution is the theme dirs' dims: the
+        # canvas (landscape) when the #136 portrait-fallback applied, else the
+        # catalog (portrait) dims. (#theme-collision)
+        theme_res = (self._pm.state.canvas_size if dirs.portrait_fallback
+                     else dirs.catalog_size)
+        themes = self._app.dispatch(ListThemes(resolution=theme_res)).themes
+        self._w['theme_local'].set_themes(themes)
         if web_dir:
             self._w['theme_web'].set_web_directory(web_dir)
         self._w['theme_web'].set_resolution(f'{bw}x{bh}')
@@ -1301,22 +1308,17 @@ class LCDHandler(BaseHandler):
         self._w['image_cut'].set_resolution(bw, bh)
         self._w['video_cut'].set_resolution(bw, bh)
 
-        # First-install auto-load: pick the first theme in the dir if
-        # the device has nothing rendered yet AND no saved theme name.
+        # First-install auto-load: nothing rendered yet AND no saved theme →
+        # load the first listed theme (user-precedence already applied by
+        # ListThemes, so a user theme wins the auto-load too).
         ds = self._app.settings.for_device(self._device_key)
         if (self._pm.state.current_theme_path is None
-                and theme_dir and theme_dir.exists()
-                and not ds.current_theme):
-            for item in sorted(theme_dir.iterdir()):
-                if item.is_dir() and (item / '00.png').exists():
-                    self.log.info("Data ready: auto-loading first theme: %s", item)
-                    self._select_theme_from_path(item, persist=True,
-                                                  overlay_config=True)
-                    return True
-            self.log.debug(
-                "_update_theme_directories: no valid theme found for auto-load in %s",
-                theme_dir,
-            )
+                and not ds.current_theme and themes):
+            first = themes[0]
+            self.log.info("Data ready: auto-loading first theme: %s", first.path)
+            self._select_theme_from_path(Path(first.path), persist=True,
+                                          overlay_config=True)
+            return True
         return False
 
     @property

--- a/src/trcc/ui/gui/lcd_handler.py
+++ b/src/trcc/ui/gui/lcd_handler.py
@@ -1246,6 +1246,11 @@ class LCDHandler(BaseHandler):
 
     # ── Helpers ─────────────────────────────────────────────────────
 
+    def refresh_themes(self) -> None:
+        """Public re-list of the local theme browser (after save / import /
+        delete) — re-dispatches ListThemes through the dir-resolution refresh."""
+        self._update_theme_directories()
+
     def _update_theme_directories(self) -> bool:
         """Reload theme browser directories for the current resolution.
 

--- a/src/trcc/ui/gui/trcc_app.py
+++ b/src/trcc/ui/gui/trcc_app.py
@@ -35,6 +35,7 @@ from PySide6.QtWidgets import (
 
 from ...core.commands import (
     ConnectDevice,
+    DeleteTheme,
     EnableOverlay,
     ListGpus,
     PlayVideo,
@@ -1738,19 +1739,27 @@ class TRCCApp(QMainWindow):
             self, "Delete Theme", f"Delete theme '{theme_info.name}'?",
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
             QMessageBox.StandardButton.No)
-        if reply == QMessageBox.StandardButton.Yes:
-            self.uc_theme_local.delete_theme(theme_info)
-            h = self._active_lcd()
-            # The handler tracks the active theme directory on its
-            # ``_state.current_theme_path``; if the deleted theme was
-            # the active one, invalidate the scene cache so the next
-            # render rebuilds from whatever falls back as background.
-            current = h.current_theme_path if h is not None else None
-            if (h is not None and current is not None
-                    and str(current) == theme_info.path):
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+        # Delete via the Command — the FS removal happens in the service,
+        # confined to the user-content tree (shipped themes are refused), so
+        # the View does no filesystem work.  Then re-list through ListThemes
+        # and forget the name from the slideshow. (#theme-collision)
+        result = self._app.dispatch(DeleteTheme(path=Path(theme_info.path)))
+        if not result.ok:
+            self.uc_preview.set_status(result.message)
+            return
+        self.uc_theme_local.forget_slideshow_theme(theme_info.name)
+        h = self._active_lcd()
+        if h is not None:
+            h.refresh_themes()
+            # If the deleted theme was the active one, invalidate the scene
+            # cache so the next render rebuilds from whatever falls back.
+            current = h.current_theme_path
+            if current is not None and str(current) == theme_info.path:
                 self._app.display.invalidate(h.device_key)
                 self.uc_preview.set_image(None)
-            self.uc_preview.set_status(f"Deleted: {theme_info.name}")
+        self.uc_preview.set_status(f"Deleted: {theme_info.name}")
 
     # ── Settings Delegates ──────────────────────────────────────────
 

--- a/src/trcc/ui/gui/uc_theme_local.py
+++ b/src/trcc/ui/gui/uc_theme_local.py
@@ -21,6 +21,7 @@ from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QLabel, QLineEdit, QPushButton
 
 from ...core.models import LocalThemeItem
+from ...core.results import ThemeListEntry
 from ..presentation.slideshow_model import SlideshowModel
 from .assets import Assets
 from .base import BaseThemeBrowser, BaseThumbnail
@@ -252,7 +253,7 @@ class UCThemeLocal(BaseThemeBrowser):
         self.filter_mode = mode
         for i, btn in enumerate(self._filter_buttons):
             btn.setChecked(i == mode)
-        self.load_themes()
+        self._render_filtered()   # re-filter the cache; no disk re-walk
         self.invoke_delegate(self.CMD_FILTER_CHANGED, mode)
 
     def load_themes(self):
@@ -309,14 +310,41 @@ class UCThemeLocal(BaseThemeBrowser):
                 ))
         log.info("uc_theme_local.load_themes: %d theme(s) found", len(all_items))
         self._all_themes = all_items
+        self._render_filtered()
 
-        # Filter for display
+    def set_themes(self, entries: list[ThemeListEntry]) -> None:
+        """Render the browser from ListThemes entries — the universal Command
+        result — instead of walking the disk in the View.
+
+        ``origin`` ("user"/"shipped") drives the user/default filter (the
+        canonical, location-derived classification); ``preview`` is the tile
+        image.  Same data feeds CLI/API/qtgui. (#theme-collision)
+        """
+        log.info("UCThemeLocal.set_themes: %d entr%s",
+                 len(entries), "y" if len(entries) == 1 else "ies")
+        self._all_themes = [
+            LocalThemeItem(
+                name=e.name, path=e.path, thumbnail=e.preview,
+                is_local=True, is_user=(e.origin == "user"),
+            )
+            for e in entries
+        ]
+        self._render_filtered()
+
+    def _render_filtered(self) -> None:
+        """Clear + repopulate the grid from the cached ``self._all_themes`` for
+        the current filter mode.  No disk access — re-runnable on a filter click
+        (the filter buttons no longer re-walk the disk)."""
+        self._clear_grid()
+        if not self._all_themes:
+            self._show_empty_message()
+            return
         if self.filter_mode == self.MODE_DEFAULT:
-            theme_dirs = [t for t in all_items if not t.is_user]
+            theme_dirs = [t for t in self._all_themes if not t.is_user]
         elif self.filter_mode == self.MODE_USER:
-            theme_dirs = [t for t in all_items if t.is_user]
+            theme_dirs = [t for t in self._all_themes if t.is_user]
         else:
-            theme_dirs = list(all_items)
+            theme_dirs = list(self._all_themes)
 
         # Tag each with its global index in the unfiltered list
         for t in theme_dirs:

--- a/src/trcc/ui/gui/uc_theme_local.py
+++ b/src/trcc/ui/gui/uc_theme_local.py
@@ -13,8 +13,6 @@ Features:
 from __future__ import annotations
 
 import logging
-import shutil
-from pathlib import Path
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QIcon
@@ -144,7 +142,6 @@ class UCThemeLocal(BaseThemeBrowser):
 
     def __init__(self, parent=None):
         self.filter_mode = self.MODE_ALL
-        self.theme_directory = None
         # Slideshow interaction state lives in a toolkit-free model; this
         # panel renders it (badges, button icon) and exposes a public API
         # so the handler never reaches into private attrs.
@@ -219,23 +216,6 @@ class UCThemeLocal(BaseThemeBrowser):
     def _no_items_message(self) -> str:
         return "No themes found"
 
-    def set_theme_directory(self, path, *extra_paths):
-        """Bind the panel to one or more on-disk theme roots.
-
-        Accepts a single path (legacy callers) or a primary + extra
-        paths so the same widget shows themes from
-        ``paths.theme_dir(w, h)`` (pkg / GitHub-downloaded) AND
-        ``paths.user_theme_dir(w, h)`` (legacy user-saved) without
-        the caller pre-merging.
-        """
-        self.theme_directory = Path(path) if path else None
-        self._extra_theme_directories = [Path(p) for p in extra_paths if p]
-        log.info(
-            "UCThemeLocal.set_theme_directory: primary=%s extras=%s",
-            self.theme_directory, self._extra_theme_directories,
-        )
-        self.load_themes()
-
     def _on_filter_clicked(self, *_qt_args):
         """Filter-button slot — reads filter mode from sender's property."""
         sender = self.sender()
@@ -255,62 +235,6 @@ class UCThemeLocal(BaseThemeBrowser):
             btn.setChecked(i == mode)
         self._render_filtered()   # re-filter the cache; no disk re-walk
         self.invoke_delegate(self.CMD_FILTER_CHANGED, mode)
-
-    def load_themes(self):
-        self._clear_grid()
-
-        # Walk each bound theme root.  Primary (theme_dir = pkg / GitHub-
-        # downloaded) + any extras (user_theme_dir = legacy user-saved).
-        # Both layouts use Theme.png or 00.png as the preview marker.
-        roots: list[Path] = []
-        if self.theme_directory and self.theme_directory.exists():
-            roots.append(self.theme_directory)
-        roots.extend(
-            p for p in getattr(self, "_extra_theme_directories", ())
-            if p and p.exists()
-        )
-        log.info("uc_theme_local.load_themes: scanning %s",
-                 [str(p) for p in roots] or "<empty — nothing bound>")
-        if not roots:
-            self._show_empty_message()
-            return
-
-        all_items: list[LocalThemeItem] = []
-        seen: set[Path] = set()
-        for root in roots:
-            for theme_dir in sorted(root.iterdir()):
-                if not theme_dir.is_dir() or theme_dir in seen:
-                    continue
-                # Accept any dir that carries a DC config OR a JSON
-                # theme config OR a preview asset.  Per the user:
-                # anything with a DC file in /data should get used.
-                has_dc = (
-                    (theme_dir / 'config1.dc').exists()
-                    or (theme_dir / 'config.json').exists()
-                    or (theme_dir / 'trcc.json').exists()
-                    or (theme_dir / 'trcc.json').exists()
-                )
-                thumb = theme_dir / 'Theme.png'
-                bg = theme_dir / '00.png'
-                preview = (
-                    thumb if thumb.exists() else (bg if bg.exists() else None)
-                )
-                if preview is None:
-                    # Fall back to ANY .png in the dir; if there isn't
-                    # one and there's no DC marker either, skip.
-                    preview = next(theme_dir.glob('*.png'), None)
-                if preview is None and not has_dc:
-                    continue
-                seen.add(theme_dir)
-                all_items.append(LocalThemeItem(
-                    name=theme_dir.name,
-                    path=str(theme_dir),
-                    thumbnail=str(preview) if preview is not None else "",
-                    is_user=theme_dir.name.startswith(('User', 'Custom')),
-                ))
-        log.info("uc_theme_local.load_themes: %d theme(s) found", len(all_items))
-        self._all_themes = all_items
-        self._render_filtered()
 
     def set_themes(self, entries: list[ThemeListEntry]) -> None:
         """Render the browser from ListThemes entries — the universal Command
@@ -475,20 +399,12 @@ class UCThemeLocal(BaseThemeBrowser):
     def get_selected_theme(self):
         return self.selected_item
 
-    def delete_theme(self, theme_info: LocalThemeItem):
-        """Delete a theme directory and refresh the list."""
-        path = Path(theme_info.path)
-        log.info("UCThemeLocal.delete_theme: name=%r path=%s",
-                 theme_info.name, path)
-        if path.exists() and path.is_dir():
-            shutil.rmtree(path)
-        else:
-            log.warning(
-                "UCThemeLocal.delete_theme: path %s missing or not a dir",
-                path,
-            )
+    def forget_slideshow_theme(self, name: str) -> None:
+        """Drop a deleted theme from the slideshow array.
 
-        # Remove from slideshow if present
-        self._slideshow_model.remove_theme(theme_info.name)
-
-        self.load_themes()
+        No filesystem, no re-list: the file removal is the ``DeleteTheme``
+        Command's job and the re-list is the handler's (``ListThemes``) — the
+        View only forgets the name from its slideshow model. (#theme-collision)
+        """
+        log.info("UCThemeLocal.forget_slideshow_theme: %r", name)
+        self._slideshow_model.remove_theme(name)

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -571,3 +571,28 @@ def test_gui_on_handlers_log_or_are_exempt() -> None:
         "GUI _on_* handler with no log (not tick/debounce-exempt) — a user "
         f"interaction would be invisible in the log: {offenders}"
     )
+
+
+def test_local_theme_browser_view_does_no_filesystem_walk() -> None:
+    """The local theme browser (``uc_theme_local``) renders ListThemes entries
+    via ``set_themes`` — it must NOT walk the disk itself.
+
+    A private disk walk in the View is exactly what diverged from the universal
+    ``ListThemes`` Command and shadowed a user-saved theme behind a same-named
+    shipped one (the green-"Theme1" collision).  This gate keeps listing +
+    deletion flowing through Commands. (#theme-collision, logging/architecture)
+    """
+    path = _SRC / "trcc" / "ui" / "gui" / "uc_theme_local.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    forbidden = {"iterdir", "glob", "rglob", "scandir", "rmtree", "walk",
+                 "listdir"}
+    offenders = [
+        f"uc_theme_local.py:{n.lineno} .{n.func.attr}()"
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+        and n.func.attr in forbidden
+    ]
+    assert not offenders, (
+        "theme browser View does filesystem traversal — listing must come from "
+        f"ListThemes (set_themes), deletion from DeleteTheme: {offenders}"
+    )

--- a/tests/test_architecture_boundaries.py
+++ b/tests/test_architecture_boundaries.py
@@ -478,3 +478,96 @@ def test_selftest_shell_true_and_os_path_collectors_have_teeth() -> None:
     op = _OsPathCollector()
     op.visit(ast.parse("p = os.path.join('a', 'b')\n"))
     assert op.lines
+
+
+def test_ok_false_results_carry_a_message() -> None:
+    """Every ``Result(ok=False, …)`` in a core Command must carry a non-empty
+    ``message``.
+
+    ``App.dispatch`` is the universal user-action log: it WARNs on every
+    ``ok=False`` outcome with ``result.message``.  A blank/absent message makes
+    a rejected user action invisible there — so the message IS the log line for
+    that branch.  This gate keeps every failure branch self-explanatory without
+    mandating a duplicate per-branch ``log`` call. (logging coverage)
+    """
+    offenders: list[str] = []
+    for path in _files_under("trcc/core/commands"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            kw = {k.arg: k.value for k in node.keywords if k.arg}
+            ok = kw.get("ok")
+            if not (isinstance(ok, ast.Constant) and ok.value is False):
+                continue
+            msg = kw.get("message")
+            blank = msg is None or (
+                isinstance(msg, ast.Constant) and not str(msg.value).strip()
+            )
+            if blank:
+                offenders.append(f"{path.relative_to(_SRC)}:{node.lineno}")
+    assert not offenders, (
+        "Result(ok=False) with no/blank message — App.dispatch's WARNING would "
+        f"be uninformative: {offenders}"
+    )
+
+
+def test_gui_on_handlers_log_or_are_exempt() -> None:
+    """Every GUI ``_on_*`` user-interaction handler must LOG — a click /
+    selection / value change is a user action and must be visible.
+
+    EXEMPT: per-tick handlers (timer-wired via ``timeout.connect`` /
+    ``make_timer``, or named ``*_tick``) which are DEBUG/silent by design, and
+    debounced live-drag handlers (they re-arm a debounce; the SETTLED value
+    logs elsewhere).  Locks in user-interaction click coverage so a new silent
+    handler fails CI. (logging coverage)
+    """
+    import re
+
+    log_methods = {"info", "debug", "warning", "error", "exception", "critical"}
+    gui_files = _files_under("trcc/ui/gui")
+    alltext = "\n".join(p.read_text(encoding="utf-8") for p in gui_files)
+    timer_wired = set(re.findall(
+        r"(?:timeout\.connect|make_timer)\(\s*self\.(\w+)", alltext))
+
+    def _logs(node: ast.AST) -> bool:
+        for n in ast.walk(node):
+            if (isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+                    and n.func.attr in log_methods):
+                base = n.func.value
+                if isinstance(base, ast.Name) and base.id in ("log", "logger"):
+                    return True
+                if (isinstance(base, ast.Attribute)
+                        and base.attr in ("log", "logger", "_log")):
+                    return True
+        return False
+
+    def _arms_debounce(fn: ast.AST) -> bool:
+        for n in ast.walk(fn):
+            if (isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+                    and n.func.attr == "start"):
+                tgt = ast.unparse(n.func.value).lower()
+                if "debounce" in tgt or "_timer" in tgt:
+                    return True
+        return False
+
+    offenders: list[str] = []
+    for path in gui_files:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for cls in [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]:
+            for fn in cls.body:
+                if (not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef))
+                        or not fn.name.startswith("_on_")):
+                    continue
+                if _logs(fn):
+                    continue
+                if fn.name in timer_wired or fn.name.endswith("_tick"):
+                    continue   # per-tick — DEBUG/silent by design
+                if _arms_debounce(fn):
+                    continue   # live-drag — settled value logs elsewhere
+                offenders.append(
+                    f"{path.relative_to(_SRC)}:{fn.lineno} {cls.name}.{fn.name}")
+    assert not offenders, (
+        "GUI _on_* handler with no log (not tick/debounce-exempt) — a user "
+        f"interaction would be invisible in the log: {offenders}"
+    )

--- a/tests/test_overlay_clock.py
+++ b/tests/test_overlay_clock.py
@@ -119,6 +119,33 @@ def test_date_element_honours_its_own_format_over_the_global() -> None:
     assert rec.drawn[0][2] != "2026/06/05"
 
 
+def test_date_element_with_default_pattern_follows_global() -> None:
+    """A date element whose pattern is the DEFAULT ("%Y/%m/%d" ≡ yyyy/MM/dd) is
+    treated as uncustomised → it follows the user's global date_format (the
+    precomputed dict), so the settings-panel choice applies.
+
+    The reconciliation of two reports: the sibling test keeps a DELIBERATE
+    pattern (%m/%d); this keeps the GLOBAL pref winning for the standard format
+    a user expects to control. (#format-prefs)
+    """
+    rec = _DrawRecorder()
+    service = OverlayService(rec)
+    base = rec.create_surface(320, 320)
+
+    service.render(
+        base,
+        _config([
+            {"type": "clock", "source": "date", "format": "%Y/%m/%d",
+             "x": 0, "y": 0},
+        ]),
+        sensors={},
+        clock={"date": "05/06/2026"},   # global pref (dd/MM/yyyy) already resolved
+    )
+
+    # Follows the global dict, NOT the element's default-equivalent pattern.
+    assert rec.drawn[0][2] == "05/06/2026"
+
+
 def test_date_element_without_pattern_uses_global_dict() -> None:
     """No real strftime pattern (e.g. the metric default "{value}") → fall
     back to the precomputed global clock dict, unchanged."""

--- a/tests/test_theme_persistence.py
+++ b/tests/test_theme_persistence.py
@@ -842,6 +842,84 @@ def test_save_theme_keeps_cloud_video_at_theme_ext(
     assert saved_video.read_bytes() == fake_mp4_bytes
 
 
+def test_resave_onto_self_keeps_in_dir_background(
+    app: App, tmp_home: Path, user_theme_dir: Path,
+) -> None:
+    """Re-saving a saved theme onto its own name must NOT lose its background.
+
+    Reproduces the data-loss bug: the first save bundles the cloud video as
+    ``Theme.mp4``, clears the bg override, and re-points the active theme at the
+    saved dir.  The SECOND save then has source == target with no override —
+    the old code rmtree'd the target before reading it, destroying ``Theme.mp4``
+    and writing ``bg=None`` (black canvas on reload).  Staging the save keeps
+    the source intact until its assets are captured.
+    """
+    source = _write_theme_with_real_pngs(tmp_home, "src")
+    app.active_themes[_TEST_DEVICE_KEY] = ThemeService().load(source)
+
+    cloud_video = tmp_home / "cloud_pool" / "loop.mp4"
+    cloud_video.parent.mkdir(parents=True)
+    video_bytes = b"\x00\x00\x00\x20ftypisom..." * 100
+    cloud_video.write_bytes(video_bytes)
+    app.settings.set_background_path(_TEST_DEVICE_KEY, str(cloud_video))
+
+    # First save bundles Theme.mp4, clears the override, and re-points the
+    # active theme at the saved dir → next save has source == target.
+    assert app.dispatch(SaveTheme(key=_TEST_DEVICE_KEY, name="loop")).ok
+    saved = user_theme_dir / "loop"
+    assert (saved / "Theme.mp4").read_bytes() == video_bytes
+    assert app.settings.for_device(_TEST_DEVICE_KEY).background_path is None
+    assert app.active_themes[_TEST_DEVICE_KEY].path == saved
+
+    # Re-save onto the same name (overwrite) — the background must survive.
+    assert app.dispatch(
+        SaveTheme(key=_TEST_DEVICE_KEY, name="loop", overwrite=True)
+    ).ok
+    assert (saved / "Theme.mp4").read_bytes() == video_bytes
+    assert app.themes.background_path(app.themes.load(saved)) is not None
+
+
+def test_save_theme_references_catalog_background_without_copying(
+    app: App, tmp_home: Path, user_theme_dir: Path,
+) -> None:
+    """A background already in the cloud/user data catalog is REFERENCED by
+    ``web/{w}{h}/<name>`` — never copied into the theme dir.
+
+    The data-ownership model: cloud downloads + user-library assets are
+    shared, so the saved theme just points at the existing file (the
+    "symlink in config").  A re-save re-emits the same ref, so the
+    background survives overwrite without any copy.
+    """
+    import json as _json
+
+    source = _write_theme_with_real_pngs(tmp_home, "src")
+    app.active_themes[_TEST_DEVICE_KEY] = ThemeService().load(source)
+
+    # A cloud-downloaded video lives under cloud_theme_dir (data_dir/web/{w}{h}).
+    cloud_dir = app.platform.paths().cloud_theme_dir(*_TEST_RES)
+    cloud_dir.mkdir(parents=True, exist_ok=True)
+    cloud_video = cloud_dir / "a023.mp4"
+    video_bytes = b"\x00\x00\x00\x20ftypisom..." * 100
+    cloud_video.write_bytes(video_bytes)
+    app.settings.set_background_path(_TEST_DEVICE_KEY, str(cloud_video))
+
+    ref = f"web/{_TEST_RES[0]}{_TEST_RES[1]}/a023.mp4"
+    assert app.dispatch(SaveTheme(key=_TEST_DEVICE_KEY, name="catref")).ok
+    saved = user_theme_dir / "catref"
+    manifest = _json.loads((saved / "trcc.json").read_text(encoding="utf-8"))
+    assert manifest["background"] == ref          # referenced…
+    assert not (saved / "Theme.mp4").exists()      # …not copied
+    assert app.themes.background_path(app.themes.load(saved)) == cloud_video
+
+    # Re-save onto the same name → ref persists, still no copy, no loss.
+    assert app.dispatch(
+        SaveTheme(key=_TEST_DEVICE_KEY, name="catref", overwrite=True)
+    ).ok
+    manifest2 = _json.loads((saved / "trcc.json").read_text(encoding="utf-8"))
+    assert manifest2["background"] == ref
+    assert not (saved / "Theme.mp4").exists()
+
+
 def test_save_theme_copies_non_catalog_mask_override_theme_local(
     app: App, tmp_home: Path, user_theme_dir: Path,
 ) -> None:

--- a/tests/test_theme_persistence.py
+++ b/tests/test_theme_persistence.py
@@ -1407,3 +1407,88 @@ def test_editing_metrics_does_not_touch_cloud_mask_dc(
 
     assert (cloud_dir / "config1.dc").read_bytes() == b"\xddORIGINAL", \
         "a cloud mask's DC must never be rewritten by a metric edit"
+
+
+def test_list_themes_user_theme_shadows_shipped_same_name(
+    app: App, user_theme_dir: Path,
+) -> None:
+    """A user-saved theme WINS over a shipped theme of the same name (the green
+    "Theme1" placeholder collision): ListThemes returns ONE entry — the user's,
+    ``origin="user"``, with a resolved preview — and leaves the shipped one on
+    disk, just shadowed.  Universal: CLI / API / GUI all dispatch this. (#theme-collision)
+    """
+    from trcc.core.commands import ListThemes
+
+    paths = app.platform.paths()
+    shipped = _write_theme_with_real_pngs(paths.theme_dir(*_TEST_RES), "Theme1")
+    user = _write_theme_with_real_pngs(user_theme_dir, "Theme1")
+
+    result = app.dispatch(ListThemes(resolution=_TEST_RES))
+    assert result.ok
+    matches = [e for e in result.themes if e.name == "Theme1"]
+    assert len(matches) == 1                        # deduped by name
+    entry = matches[0]
+    assert entry.origin == "user"
+    assert Path(entry.path) == user                 # the user dir, not the placeholder
+    assert entry.preview                            # tile image resolved
+    assert shipped.exists()                         # shipped untouched, just shadowed
+
+
+def test_list_themes_classifies_origin_by_location(
+    app: App, user_theme_dir: Path,
+) -> None:
+    """Origin is location-derived (under user_data_dir → "user"), not name-based —
+    a user theme NOT named User*/Custom* is still origin="user"."""
+    from trcc.core.commands import ListThemes
+
+    paths = app.platform.paths()
+    _write_theme_with_real_pngs(paths.theme_dir(*_TEST_RES), "Aurora")   # shipped
+    _write_theme_with_real_pngs(user_theme_dir, "MyMix")                 # user
+
+    by_name = {e.name: e for e in app.dispatch(ListThemes(resolution=_TEST_RES)).themes}
+    assert by_name["Aurora"].origin == "shipped"
+    assert by_name["MyMix"].origin == "user"
+
+
+def test_restore_prefers_user_theme_over_shadowed_shipped(
+    app: App, user_theme_dir: Path,
+) -> None:
+    """A persisted ``current_theme`` at a SHIPPED theme that a same-named USER
+    theme now shadows self-heals on restore: RestoreLastTheme re-resolves to the
+    user theme (user-wins, consistent with ListThemes — the green-Theme1
+    collision). (#theme-collision)
+    """
+    paths = app.platform.paths()
+    shipped = _write_theme_with_real_pngs(paths.theme_dir(*_TEST_RES), "Theme1")
+    user = _write_theme_with_real_pngs(user_theme_dir, "Theme1")
+    app.active_themes[_TEST_DEVICE_KEY] = ThemeService().load(shipped)
+    app.settings.set_current_theme(_TEST_DEVICE_KEY, str(shipped.resolve()))
+
+    assert app.dispatch(RestoreLastTheme(key=_TEST_DEVICE_KEY)).ok
+    restored = Path(app.settings.for_device(_TEST_DEVICE_KEY).current_theme)
+    assert restored.resolve() == user.resolve()       # the user theme, not the shipped placeholder
+
+
+def test_restore_keeps_shipped_when_no_user_shadow(app: App) -> None:
+    """No same-named user theme → RestoreLastTheme loads the stored shipped
+    theme unchanged (no regression)."""
+    paths = app.platform.paths()
+    shipped = _write_theme_with_real_pngs(paths.theme_dir(*_TEST_RES), "Aurora")
+    app.active_themes[_TEST_DEVICE_KEY] = ThemeService().load(shipped)
+    app.settings.set_current_theme(_TEST_DEVICE_KEY, str(shipped.resolve()))
+
+    assert app.dispatch(RestoreLastTheme(key=_TEST_DEVICE_KEY)).ok
+    restored = Path(app.settings.for_device(_TEST_DEVICE_KEY).current_theme)
+    assert restored.resolve() == shipped.resolve()
+
+
+def test_restore_keeps_user_theme_unchanged(app: App, user_theme_dir: Path) -> None:
+    """current_theme already at a user theme → unchanged (prefer-user is a no-op
+    for non-shipped paths)."""
+    user = _write_theme_with_real_pngs(user_theme_dir, "MyMix")
+    app.active_themes[_TEST_DEVICE_KEY] = ThemeService().load(user)
+    app.settings.set_current_theme(_TEST_DEVICE_KEY, str(user.resolve()))
+
+    assert app.dispatch(RestoreLastTheme(key=_TEST_DEVICE_KEY)).ok
+    restored = Path(app.settings.for_device(_TEST_DEVICE_KEY).current_theme)
+    assert restored.resolve() == user.resolve()

--- a/tests/ui/presentation/test_theme_local_binding.py
+++ b/tests/ui/presentation/test_theme_local_binding.py
@@ -29,3 +29,31 @@ def test_set_slideshow_state_disabled_clears(qtbot) -> None:
 
     assert panel.is_slideshow() is False
     assert panel.get_slideshow_themes() == []      # no names → no resolved items
+
+
+def test_set_themes_renders_entries_and_origin_drives_filter(qtbot) -> None:
+    """The View renders ListThemes entries (no disk walk): ``origin`` maps to
+    is_user (location-derived) and drives the user/default filter; ``preview``
+    is the tile image. (#theme-collision)"""
+    from trcc.core.results import ThemeListEntry
+
+    panel = UCThemeLocal()
+    qtbot.addWidget(panel)
+
+    panel.set_themes([
+        ThemeListEntry(name="MyMix", resolution=(320, 320), path="/u/MyMix",
+                       preview="/u/MyMix/Theme.png", origin="user"),
+        ThemeListEntry(name="Aurora", resolution=(320, 320), path="/s/Aurora",
+                       preview="/s/Aurora/00.png", origin="shipped"),
+    ])
+
+    by_name = {i.name: i for i in panel._all_themes}
+    assert by_name["MyMix"].is_user is True            # origin-derived, not name-based
+    assert by_name["Aurora"].is_user is False
+    assert by_name["MyMix"].thumbnail == "/u/MyMix/Theme.png"
+
+    panel.filter_mode = panel.MODE_USER
+    panel._render_filtered()
+    shown = [w.item_info.name for w in panel.item_widgets
+             if hasattr(w, "item_info")]
+    assert shown == ["MyMix"]                          # only the user-origin theme


### PR DESCRIPTION
Theme subsystem made correct + universal (every UI dispatches Commands), in verified increments.

## Bugs fixed
- **Background lost on save** — `SaveTheme` references catalog assets (`web/{w}{h}`) instead of copying, and stages-then-swaps so re-saving a theme onto its own name no longer rmtree's the source before reading it (silent data loss → black canvas).
- **No preview on startup** — symptom of the above; `RestoreLastTheme` also self-heals a stale `current_theme` that points at a shipped theme a same-named user theme now shadows.
- **Same-name collision (e.g. saved `Theme1` shadowed by a shipped green `Theme1`)** — user-precedence is now a core domain rule (`ListThemes`: user dir first, dedupe by name, `origin` location-derived), applied identically in CLI/API/GUI and on restore.
- **Settings-panel date format not applying** — reconciled at the render (universal): a deliberate non-default theme pattern (`%m/%d`) is honoured; a default-equivalent pattern follows the user's global `date_format`. Both prior reports covered by tests.

## Architecture
- The GUI theme browser renders `ListThemes` entries via `set_themes` — **no filesystem walk in the View**; deletion routes through the `DeleteTheme` Command (confined to the user-content tree). Locked by a new architecture-boundary gate.
- Logging: not-connected `raise`s now log before propagating; gates assert every `Result(ok=False)` carries a message and every GUI `_on_*` handler logs.

## Verified
Full suite **2364 passed / 4 skipped**, architecture smoke **20/20**, ruff + pyright clean. Each commit landed green. Real-GUI eyeball still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)