### PR TITLE
fix(udev): don't use impure paths

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -117,7 +117,7 @@
           config = lib.mkIf cfg.enable {
             environment.systemPackages = [ self.packages.${pkgs.system}.default ];
 
-            services.udev.extraRules = builtins.readFile ./packaging/udev/99-trcc-lcd.rules;
+            services.udev.extraRules = builtins.replaceStrings [ "/bin/chmod" ] [ "${pkgs.coreutils}/bin/chmod" ] (builtins.readFile ./packaging/udev/99-trcc-lcd.rules);
 
             boot.kernelModules = [ "sg" ];
 


### PR DESCRIPTION
## Summary

The NixOS docs seem to be a bit out of date so I don't know if there is an official way to fix this already?
The module currently fails on NixOS as it the udev rule references an impure path `/bin/chmod` which doesn't exist on there. One proposed solution is replacing the impure path with a pure one to resolves the issue. 

## Checklist

- [ ] Tests pass (`pytest -v --tb=short`)
- [x] Linter clean (`ruff check .`)
- [x] Tested on hardware (if device-specific change)
- [ ] New tests added (if adding functionality)
