### PR TITLE
flake.nix: reuse version from pyproject.toml

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       in {
         packages.default = python.pkgs.buildPythonApplication {
           pname = "trcc-linux";
-          version = "9.7.10";
+          version = (builtins.fromTOML (builtins.readFile ./pyproject.toml)).project.version;
           pyproject = true;
 
           src = ./.;


### PR DESCRIPTION
## Summary

This is a simple mechanical change that imports the version of the project from the `pyproject.toml`. [Relase-Commits](https://github.com/Lexonight1/thermalright-trcc-linux/commit/3078965bd1e3e865550854d64f4be70cf48febcd) don't have to touch too many files this way.
## Checklist

- [ ] Tests pass (`pytest -v --tb=short`)
- [ ] Linter clean (`ruff check .`)
- [ ] Tested on hardware (if device-specific change)
- [ ] New tests added (if adding functionality)
