### PR TITLE
doc: fix nixos installation guide

### DIFF
--- a/doc/GUIDE_INSTALL.md
+++ b/doc/GUIDE_INSTALL.md
@@ -234,13 +234,24 @@ trcc gui
 
 Covers: NixOS 24.05+, NixOS unstable
 
-NixOS is different from other distros — you declare packages in a config file instead of downloading them. Add to your `flake.nix`:
+NixOS is different from other distros — you declare packages in a config file instead of downloading them. Add to your `flake.nix` and `configuration.nix`:
 
 ```nix
+# flake.nix
 {
   inputs.trcc-linux.url = "github:Lexonight1/thermalright-trcc-linux";
+  # ...
+}
+```
 
-  # In your system configuration:
+```nix
+# configuration.nix
+{ inputs, ... }:
+{
+  imports = [
+    inputs.trcc-linux.nixosModules.default
+  ];
+
   programs.trcc-linux.enable = true;
 }
 ```


### PR DESCRIPTION
## Summary

This makes it more clear that the import of the default nixos module is required. This doesn't have to be merged 1:1, this is more a suggestion on how to improve the docs.

## Checklist

- [ ] Tests pass (`pytest -v --tb=short`)
- [ ] Linter clean (`ruff check .`)
- [ ] Tested on hardware (if device-specific change)
- [ ] New tests added (if adding functionality)
