### PR TITLE
feat(led): add Thermalright Magic Qube support (0416:8001)

### DIFF
--- a/src/trcc/adapters/device/led.py
+++ b/src/trcc/adapters/device/led.py
@@ -26,7 +26,13 @@ from ...core.errors import (
     UnsupportedOperationError,
 )
 from ...core.led_models import LedPayload
-from ...core.led_protocol import remap_led_colors, resolve_pm
+from ...core.led_protocol import (
+    is_fingerprint_header,
+    remap_led_colors,
+    resolve_handshake,
+    resolve_model_name,
+    resolve_pm,
+)
 from ...core.models import HandshakeResult, LedHandshakeResult, ProductInfo, Wire
 from ...core.ports import BulkTransport, Device
 from . import DeviceFactory
@@ -206,11 +212,15 @@ class Led(Device[BulkTransport]):
                     time.sleep(_HANDSHAKE_RETRY_DELAY_S)
                     continue
 
-                # Windows DeviceDataReceived1 doesn't validate magic/cmd —
-                # we warn on mismatch but accept.
-                if resp[0:4] != _MAGIC:
-                    log.warning("Led handshake: unexpected magic %s", resp[0:4].hex())
-                if len(resp) > 12 and resp[12] != 1:
+                # Windows DeviceDataReceived1 doesn't validate magic/cmd — we
+                # accept regardless.  A recognised fingerprint header (e.g. the
+                # Magic Qube's DC DD AA 01) is expected, so only warn on a truly
+                # unknown magic / cmd byte.
+                header = bytes(resp[0:4])
+                recognised = is_fingerprint_header(header)
+                if header != _MAGIC and not recognised:
+                    log.warning("Led handshake: unexpected magic %s", header.hex())
+                if len(resp) > 12 and resp[12] != 1 and not recognised:
                     log.warning("Led handshake: unexpected cmd byte %d", resp[12])
 
                 # PM and SUB extraction — matches Windows UCDevice.cs offsets:
@@ -218,10 +228,13 @@ class Led(Device[BulkTransport]):
                 self._pm = resp[5]
                 self._sub = resp[4]
 
-                # PM byte → device style + readable model name. Falls back to
-                # the registry's ``led_style`` / ``product`` when the firmware
-                # reports a PM not in PmRegistry (e.g. a new SKU).
-                entry = resolve_pm(self._pm, self._sub)
+                # Handshake → device style + readable model name.  The header
+                # fingerprint wins first (some SKUs reuse a PM byte but ship a
+                # distinct handshake header — e.g. the Magic Qube shares PM=208
+                # with CZ1 but answers with DC DD AA 01), then the PM registry.
+                # Falls back to the registry's ``led_style`` / ``product`` when
+                # the firmware reports a PM not in PmRegistry (e.g. a new SKU).
+                entry = resolve_handshake(header, self._pm, self._sub)
                 if entry is not None:
                     style = entry.style
                     model_name = entry.model_name
@@ -278,7 +291,10 @@ class Led(Device[BulkTransport]):
         cached = _probe_cache_load(self.info.vid, self.info.pid)
         if cached is not None:
             cpm, csub, cname = cached
-            entry = resolve_pm(cpm, csub)
+            # A fingerprint device (e.g. Magic Qube) shares its PM byte with
+            # another product, so recover it by cached model name first — the
+            # cache doesn't persist the handshake header — then by PM byte.
+            entry = resolve_model_name(cname) or resolve_pm(cpm, csub)
             log.warning(
                 "Led handshake: live failed after %d retries — using "
                 "disk cache (PM=%d SUB=%d model=%s, last_err=%s)",

--- a/src/trcc/core/commands/device.py
+++ b/src/trcc/core/commands/device.py
@@ -191,18 +191,29 @@ class ConnectDevice(Command[ConnectResult]):
                     override.button_image or "(cutout-only)",
                 )
 
-        # LED style: enrich ``led_style`` from the same handshake fingerprint.
-        # The registry leaves it None ("resolved at runtime from PM byte"), so
-        # without this the LED handler reads None and falls back to a default
-        # style.  resolve_pm lives in core, so this stays inside the hexagon.
+        # LED style: enrich ``led_style`` from the handshake.  The registry
+        # leaves it None ("resolved at runtime"), so without this the LED
+        # handler reads None and falls back to a default style.  Prefer the
+        # LED adapter's already-resolved style — it honours the header
+        # fingerprint, so a Magic Qube (shares PM=208 with CZ1) isn't
+        # mis-tagged as CZ1 — and fall back to the header/PM registry from the
+        # raw handshake bytes.  resolve_* live in core, so this stays inside
+        # the hexagon.
         if device.info.wire is Wire.LED and device.info.led_style is None:
-            from ..led_protocol import resolve_pm
-            led_entry = resolve_pm(handshake.pm_byte, handshake.sub_byte)
-            if led_entry is not None and led_entry.style is not None:
-                device.info = _dc_replace(device.info, led_style=led_entry.style)
+            led_hs = getattr(device, "led_handshake", None)
+            led_style = getattr(led_hs, "style", None)
+            if led_style is None:
+                from ..led_protocol import resolve_handshake
+                led_entry = resolve_handshake(
+                    handshake.raw_response[:4],
+                    handshake.pm_byte, handshake.sub_byte,
+                )
+                led_style = led_entry.style if led_entry is not None else None
+            if led_style is not None:
+                device.info = _dc_replace(device.info, led_style=led_style)
                 log.info(
-                    "ConnectDevice %s: LED style PM=%d → %s",
-                    self.key, handshake.pm_byte, led_entry.style.value,
+                    "ConnectDevice %s: LED style → %s",
+                    self.key, led_style.value,
                 )
 
         # Install theme/cloud/mask data for the HANDSHAKE-resolved resolution.

--- a/src/trcc/core/led_models.py
+++ b/src/trcc/core/led_models.py
@@ -200,6 +200,10 @@ LEGACY_STYLE_ID: dict[LedStyle, int] = {
     LedStyle.LF11:  10,
     LedStyle.LF15:  11,
     LedStyle.LF13:  12,
+    # Synthetic id for the Linux-added Magic Qube (no legacy C# style_id);
+    # continues the sequence so every LED_STYLES entry has an id.  It shows
+    # plain sensor gauges (led_panel_for treats any non-LC1/LF11/LC2 id so).
+    LedStyle.MAGIC_QUBE: 13,
 }
 
 # Inverse lookup — legacy int → :class:`LedStyle` enum.  Used by GUI
@@ -268,6 +272,13 @@ LED_STYLES: dict[LedStyle, LedStyleSpec] = {
                                  zone_assets=_ZONE_BTN_MODE56),
     LedStyle.LF13:  LedStyleSpec(62,  62, 0, "LF13",
                                  "led_preview_lf13",  "led_bg_lf13"),
+    # Magic Qube — 65 LEDs: two 7-seg digits (3 LEDs/segment, LED 0-41) + 4
+    # corner metric indicators (42-49) + a 15-LED contour border (50-64).
+    # Same 2-digit / 4-phase design as CZ1.  Reuses the generic segment assets
+    # until dedicated art is added.
+    LedStyle.MAGIC_QUBE: LedStyleSpec(65, 14, 4, "MAGIC_QUBE",
+                                      "led_preview_cz1", "led_bg_segment",
+                                      zone_assets=_ZONE_BTN_N),
 }
 
 
@@ -302,6 +313,7 @@ ZONE_STYLE_ASSETS: dict[LedStyle, tuple[tuple[str, str], ...]] = {
     LedStyle.LF10:  _ZONE_ASSETS_BTNN,
     LedStyle.CZ1:   _ZONE_ASSETS_BTNN,
     LedStyle.LF11:  _ZONE_ASSETS_BTNN,
+    LedStyle.MAGIC_QUBE: _ZONE_ASSETS_BTNN,
 }
 
 

--- a/src/trcc/core/led_protocol.py
+++ b/src/trcc/core/led_protocol.py
@@ -114,6 +114,65 @@ def resolve_pm(pm: int, sub_type: int = 0) -> PmEntry | None:
     return _PM_REGISTRY.get(pm)
 
 
+# =========================================================================
+# Handshake fingerprint overrides
+# =========================================================================
+#
+# A product can reuse another device's PM byte yet ship a distinct firmware
+# handshake header, leaving the PM byte alone ambiguous.  The Thermalright
+# Magic Qube reports PM=208 (same as CZ1) but answers the HID handshake with
+# the header ``DC DD AA 01`` instead of the standard ``DA DB DC DD`` — the
+# only wire-level signal that tells it apart from a genuine CZ1.  Header
+# overrides are checked before the PM registry.
+
+_HEADER_OVERRIDES: dict[bytes, PmEntry] = {
+    bytes([0xDC, 0xDD, 0xAA, 0x01]): PmEntry(LedStyle.MAGIC_QUBE, "MAGIC_QUBE"),
+}
+
+_OVERRIDES_BY_MODEL: dict[str, PmEntry] = {
+    entry.model_name: entry for entry in _HEADER_OVERRIDES.values()
+}
+
+
+def resolve_handshake(
+    header: bytes, pm: int, sub_type: int = 0,
+) -> PmEntry | None:
+    """Resolve a device from its handshake — header fingerprint first.
+
+    A handful of products reuse another device's PM byte but ship a distinct
+    handshake header (firmware fingerprint).  When the leading four header
+    bytes match a known override that entry wins; otherwise we fall back to
+    the PM-byte registry (:func:`resolve_pm`).
+    """
+    entry = _HEADER_OVERRIDES.get(bytes(header[:4]))
+    if entry is not None:
+        log.info("resolve_handshake: header %s → %s (overrides pm=%d)",
+                 bytes(header[:4]).hex(), entry.model_name, pm)
+        return entry
+    return resolve_pm(pm, sub_type)
+
+
+def resolve_model_name(model_name: str) -> PmEntry | None:
+    """Resolve a fingerprint-override entry by its model name.
+
+    Used by the probe-cache fallback: the cache persists the model name, not
+    the handshake header, so a cached fingerprint device is recovered by
+    name.  Returns ``None`` for names not carried by an override — the caller
+    then falls back to the PM registry.
+    """
+    return _OVERRIDES_BY_MODEL.get(model_name)
+
+
+def is_fingerprint_header(header: bytes) -> bool:
+    """Whether the handshake header matches a known device fingerprint.
+
+    Lets the LED adapter treat a recognised non-standard header (e.g. the
+    Magic Qube's ``DC DD AA 01``) as expected instead of logging it as an
+    anomaly next to the standard ``DA DB DC DD`` magic.
+    """
+    return bytes(header[:4]) in _HEADER_OVERRIDES
+
+
 # ═══════════════════════════════════════════════════════════════════════
 # Wire-order remap tables
 # ═══════════════════════════════════════════════════════════════════════
@@ -322,6 +381,9 @@ __all__ = [
     "LED_REMAP_SUB_TABLES",
     "LED_REMAP_TABLES",
     "PmEntry",
+    "is_fingerprint_header",
     "remap_led_colors",
+    "resolve_handshake",
+    "resolve_model_name",
     "resolve_pm",
 ]

--- a/src/trcc/core/models.py
+++ b/src/trcc/core/models.py
@@ -187,6 +187,7 @@ class LedStyle(str, Enum):
     LF11 = "lf11"       # legacy style_id 10
     LF15 = "lf15"       # legacy style_id 11
     LF13 = "lf13"       # legacy style_id 12
+    MAGIC_QUBE = "magic_qube"  # Linux-added: Thermalright Magic Qube (no legacy style_id)
 
 
 # =========================================================================

--- a/src/trcc/services/led_segment.py
+++ b/src/trcc/services/led_segment.py
@@ -702,6 +702,92 @@ class CZ1Display(SegmentDisplay):
 
 
 # ═══════════════════════════════════════════════════════════════════════
+# Magic Qube (50 LEDs, two 7-seg digits × 3-LED segments, 4-phase rotation)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+# Physical wire order of the 7 segments within one Magic Qube digit, 3 LEDs
+# each (empirically mapped on hardware): c, d, e, g, b, a, f.
+_QUBE_WIRE: tuple[str, ...] = ("c", "d", "e", "g", "b", "a", "f")
+
+
+def _qube_digit_segmap(base: int) -> dict[str, tuple[int, int, int]]:
+    """Map each 7-seg label → its 3 LED indices for a digit starting at ``base``."""
+    pos = {seg: i for i, seg in enumerate(_QUBE_WIRE)}
+    return {
+        seg: (base + pos[seg] * 3, base + pos[seg] * 3 + 1, base + pos[seg] * 3 + 2)
+        for seg in "abcdefg"
+    }
+
+
+class MagicQubeDisplay(SegmentDisplay):
+    """Thermalright Magic Qube — 50 LEDs: two 7-seg digits + 4 indicators.
+
+    Both digits render ONE 2-digit value (left = tens, right = units); a
+    single corner indicator lights to name the metric, rotating through the
+    four phases like CZ1.  Each segment is 3 physical LEDs in wire order
+    c, d, e, g, b, a, f; the right digit is LED 0-20, the left 21-41; the
+    four indicator pairs are 42-49 (clockwise from top-left).  Mapped
+    empirically on hardware (no reference implementation exists).
+    """
+
+    mask_size = 65
+    phase_count = 4
+
+    LEFT = _qube_digit_segmap(21)   # tens digit (physically left)
+    RIGHT = _qube_digit_segmap(0)   # units digit (physically right)
+
+    # Indicator LED pairs, clockwise from top-left.
+    IND_CPU_TEMP = (42, 43)
+    IND_GPU_TEMP = (44, 45)
+    IND_GPU_LOAD = (46, 47)
+    IND_CPU_LOAD = (48, 49)
+
+    # Contour/border LEDs — always lit; they take the effect colour (the
+    # segments/indicators are gated by the value mask, the border is not).
+    BORDER = tuple(range(50, 65))
+
+    PHASES: tuple[tuple[str, tuple[int, int]], ...] = (
+        ("cpu_temp",    IND_CPU_TEMP),
+        ("gpu_temp",    IND_GPU_TEMP),
+        ("gpu_usage",   IND_GPU_LOAD),
+        ("cpu_percent", IND_CPU_LOAD),
+    )
+
+    # Each digit is one cohesive colour group (right 0-20, left 21-41); the
+    # indicators ride along in the swept "rest" group (#193).
+    color_groups = _digit_color_groups(
+        mask_size, (tuple(range(21)), tuple(range(21, 42))),
+    )
+
+    def _encode_qube_digit(
+        self, ch: str, segmap: dict[str, tuple[int, int, int]], mask: list[bool],
+    ) -> None:
+        """Light the 3 LEDs of every segment the character ``ch`` needs."""
+        for seg in self.CHAR_7SEG.get(ch, set()):
+            for led in segmap[seg]:
+                mask[led] = True
+
+    def compute_mask(
+        self, metrics: HardwareMetrics, phase: int = 0, temp_unit: str = "C", **kw: Any,
+    ) -> list[bool]:
+        mask = [False] * self.mask_size
+        metric_key, indicator = self.PHASES[phase % self.phase_count]
+        for idx in indicator:
+            mask[idx] = True
+        value = int(getattr(metrics, metric_key, 0))
+        if "temp" in metric_key:
+            value = self._to_display_temp(value, temp_unit)
+        value = max(0, min(99, value))
+        tens, units = divmod(value, 10)
+        self._encode_qube_digit(str(tens) if tens else " ", self.LEFT, mask)
+        self._encode_qube_digit(str(units), self.RIGHT, mask)
+        for idx in self.BORDER:
+            mask[idx] = True
+        return mask
+
+
+# ═══════════════════════════════════════════════════════════════════════
 # Style 9 — LC2 (61 LEDs, clock display, 7 decoration)
 # ═══════════════════════════════════════════════════════════════════════
 
@@ -828,6 +914,7 @@ DISPLAYS: dict[LedStyle, SegmentDisplay] = {
     LedStyle.LC2:   LC2Display(),
     LedStyle.LF11:  LF11Display(),
     LedStyle.LF15:  LF8Display(),   # LF15 = same layout as LF8
+    LedStyle.MAGIC_QUBE: MagicQubeDisplay(),
     # LedStyle.LF13 — pure RGB, no digit display
 }
 

--- a/src/trcc/ui/gui/uc_led_control.py
+++ b/src/trcc/ui/gui/uc_led_control.py
@@ -161,7 +161,9 @@ _STYLE_CHECKABLE_BTN = (
 # overlays (full i18n): AX120(1)+PA120(2) [led_zone_mode_1-4], AK120(3)+LF8(5)+
 # LF12(6)+LF15(11) [led_zone_mode_5-6], LC1(4)+LF11(10) [panel bg].  CZ1(8) keeps
 # its baked bg labels (not cleared); LF10(7) is colour-zones (no metric text).
-_OVERLAY_BUTTON_STYLES = frozenset({1, 2, 3, 4, 5, 6, 10, 11})
+# Magic Qube(13) has no baked-label art (generic segment bg) → overlay the
+# tr() page labels on the plain button frame, like the LC1/LF11 group.
+_OVERLAY_BUTTON_STYLES = frozenset({1, 2, 3, 4, 5, 6, 10, 11, 13})
 
 # Button labels for styles whose model carries none (PA120 is ZONE → page_labels
 # must stay () per the model invariant, but its zones *are* the 4 metrics).

--- a/src/trcc/ui/gui/uc_screen_led.py
+++ b/src/trcc/ui/gui/uc_screen_led.py
@@ -385,11 +385,36 @@ _POS_12: tuple[tuple[int, int, int, int], ...] = (
     (0, 0, 460, 460),
 )
 
+# Style 13: Magic Qube (50 LEDs) — two 7-seg digits, 3 LEDs per segment in
+# wire order c,d,e,g,b,a,f (right digit LEDs 0-20, left 21-41), + 4 corner
+# metric indicators, 2 LEDs each (42-49).  Derived by splitting the CZ1
+# segment rects so the preview aligns with the reused CZ1 deco background.
+_POS_13: tuple[tuple[int, int, int, int], ...] = (
+    (430, 240, 30, 65), (430, 305, 30, 65), (430, 370, 30, 66),
+    (264, 430, 57, 30), (321, 430, 57, 30), (378, 430, 58, 30),
+    (240, 240, 30, 65), (240, 305, 30, 65), (240, 370, 30, 66),
+    (264, 215, 57, 30), (321, 215, 57, 30), (378, 215, 58, 30),
+    (430, 24, 30, 65), (430, 89, 30, 65), (430, 154, 30, 66),
+    (264, 0, 57, 30), (321, 0, 57, 30), (378, 0, 58, 30),
+    (240, 24, 30, 65), (240, 89, 30, 65), (240, 154, 30, 66),
+    (190, 240, 30, 65), (190, 305, 30, 65), (190, 370, 30, 66),
+    (24, 430, 57, 30), (81, 430, 57, 30), (138, 430, 58, 30),
+    (0, 240, 30, 65), (0, 305, 30, 65), (0, 370, 30, 66),
+    (24, 215, 57, 30), (81, 215, 57, 30), (138, 215, 58, 30),
+    (190, 24, 30, 65), (190, 89, 30, 65), (190, 154, 30, 66),
+    (24, 0, 57, 30), (81, 0, 57, 30), (138, 0, 58, 30),
+    (0, 24, 30, 65), (0, 89, 30, 65), (0, 154, 30, 66),
+    (73, 114, 36, 16), (109, 114, 37, 16), (313, 114, 36, 16),
+    (349, 114, 37, 16), (313, 330, 36, 16), (349, 330, 37, 16),
+    (73, 330, 36, 16), (109, 330, 37, 16),
+)
+
 # Style → position array mapping
 STYLE_POSITIONS: dict[int, tuple[tuple[int, int, int, int], ...]] = {
     1: _POS_1, 2: _POS_2, 3: _POS_3, 4: _POS_4,
     5: _POS_5, 6: _POS_6, 7: _POS_7, 8: _POS_8,
     9: _POS_9, 10: _POS_10, 11: _POS_11, 12: _POS_12,
+    13: _POS_13,
 }
 
 
@@ -426,6 +451,12 @@ _DECO: dict[int, _DecoConfig] = {
     ),
     # Style 8 (CZ1): full background decoration
     8: _DecoConfig(
+        images=[("screen_led_deco_cz1", 0, 0)],
+        color_fills=[],
+    ),
+    # Style 13 (Magic Qube): same two-digit + 4-corner-label layout as CZ1 —
+    # reuse the CZ1 deco background (identical CPU°C/GPU°C/CPU%/GPU% labels).
+    13: _DecoConfig(
         images=[("screen_led_deco_cz1", 0, 0)],
         color_fills=[],
     ),

--- a/src/trcc/ui/presentation/led_display.py
+++ b/src/trcc/ui/presentation/led_display.py
@@ -81,6 +81,8 @@ _DISPLAY: dict[int, LedDisplayModel] = {
                          "Read Rate (MB/s)", "Write Rate (MB/s)")),        # LF11
     11: LedDisplayModel(11, LedSelector.PAGE, 2, ("CPU", "GPU")),          # LF15
     12: LedDisplayModel(12, LedSelector.NONE, 0, ()),                      # LF13 (solid)
+    13: LedDisplayModel(13, LedSelector.PAGE, 4,
+                        ("CPU Temp", "GPU Temp", "GPU %", "CPU %")),       # Magic Qube
 }
 
 _DEFAULT = LedDisplayModel(0, LedSelector.NONE, 0, ())

--- a/tests/test_led_pm_registry.py
+++ b/tests/test_led_pm_registry.py
@@ -26,6 +26,9 @@ from trcc.adapters.device.led import (
 from trcc.core.led_protocol import (
     _PM_REGISTRY,
     PmEntry,
+    is_fingerprint_header,
+    resolve_handshake,
+    resolve_model_name,
     resolve_pm,
 )
 from trcc.core.models import Kind, LedStyle, ProductInfo, Wire
@@ -279,3 +282,113 @@ def test_led_probe_cache_handles_corrupt_file(
     import json as _json
     cache = _json.loads(cache_path.read_text(encoding="utf-8"))
     assert cache[f"{0x0416:04x}_{0x8001:04x}"]["pm"] == 128
+
+
+# =========================================================================
+# Magic Qube — handshake fingerprint override (shares PM=208 with CZ1)
+# =========================================================================
+
+_QUBE_HEADER = bytes([0xDC, 0xDD, 0xAA, 0x01])
+
+
+def _scripted_qube_response() -> bytes:
+    """A 64-byte Magic Qube handshake reply.
+
+    Mirrors the real hardware capture ``dc dd aa 01 00 d0 d0 …``: the
+    non-standard header, SUB=0, PM=208 at both offset 5 and 6, and no
+    cmd-ACK byte at offset 12 (the firmware leaves it 0).
+    """
+    buf = bytearray(_HID_REPORT_SIZE)
+    buf[0:4] = _QUBE_HEADER
+    buf[4] = 0      # SUB
+    buf[5] = 208    # PM (0xD0)
+    buf[6] = 208
+    return bytes(buf)
+
+
+def test_resolve_handshake_header_override_wins() -> None:
+    """The Magic Qube header routes PM=208 to MAGIC_QUBE, not CZ1."""
+    entry = resolve_handshake(_QUBE_HEADER, 208, 0)
+    assert entry == PmEntry(LedStyle.MAGIC_QUBE, "MAGIC_QUBE")
+
+
+def test_resolve_handshake_standard_header_keeps_registry() -> None:
+    """A standard header falls through to the PM registry (real CZ1)."""
+    assert resolve_handshake(_MAGIC, 208, 0) == PmEntry(LedStyle.CZ1, "CZ1")
+    assert resolve_handshake(_MAGIC, 80, 0) == PmEntry(LedStyle.LF12, "LF12")
+
+
+def test_resolve_model_name_recovers_override() -> None:
+    """Cached fingerprint devices resolve back by model name."""
+    assert resolve_model_name("MAGIC_QUBE") == PmEntry(
+        LedStyle.MAGIC_QUBE, "MAGIC_QUBE",
+    )
+    assert resolve_model_name("CZ1") is None   # PM-registry devices excluded
+
+
+def test_is_fingerprint_header() -> None:
+    """The Magic Qube header is a known fingerprint; the standard magic isn't."""
+    assert is_fingerprint_header(_QUBE_HEADER) is True
+    assert is_fingerprint_header(_MAGIC) is False
+    assert is_fingerprint_header(bytes(4)) is False
+
+
+def test_led_connect_magic_qube_from_header() -> None:
+    """Full Led.connect with the Magic Qube header → MAGIC_QUBE style."""
+    transport = FakeBulkTransport()
+    transport.read_script.append(_scripted_qube_response())
+    led = Led(_led_info(), transport)
+
+    led.connect()
+
+    hs = led.led_handshake
+    assert hs is not None
+    assert hs.pm == 208
+    assert hs.style is LedStyle.MAGIC_QUBE
+    assert hs.model_name == "MAGIC_QUBE"
+
+
+def test_led_connect_magic_qube_no_anomaly_warnings(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A recognised fingerprint header must not log magic/cmd anomaly warnings."""
+    transport = FakeBulkTransport()
+    transport.read_script.append(_scripted_qube_response())
+    led = Led(_led_info(), transport)
+
+    with caplog.at_level("WARNING"):
+        led.connect()
+
+    assert not any("unexpected magic" in r.message for r in caplog.records)
+    assert not any("unexpected cmd" in r.message for r in caplog.records)
+
+
+def test_led_connect_cache_fallback_preserves_magic_qube(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cached Magic Qube recovers as MAGIC_QUBE, not CZ1.
+
+    The cache persists the model name but not the handshake header, so
+    the fallback must recover the fingerprint device by name — otherwise
+    PM=208 would resolve to CZ1 and drive the wrong layout.
+    """
+    import json as _json
+
+    from trcc.adapters.device import led as led_mod
+    cache_path = tmp_path / "led_probe_cache.json"
+    cache_path.write_text(_json.dumps({
+        f"{0x0416:04x}_{0x8001:04x}": {
+            "pm": 208, "sub": 0, "model_name": "MAGIC_QUBE",
+        },
+    }), encoding="utf-8")
+    monkeypatch.setattr(led_mod, "_PROBE_CACHE_PATH", cache_path)
+
+    transport = FakeBulkTransport()   # empty script → live handshake fails
+    led = Led(_led_info(), transport)
+
+    led.connect()
+
+    hs = led.led_handshake
+    assert hs is not None
+    assert hs.style is LedStyle.MAGIC_QUBE
+    assert hs.model_name == "MAGIC_QUBE"

--- a/tests/test_led_segment.py
+++ b/tests/test_led_segment.py
@@ -1,0 +1,119 @@
+"""Magic Qube segment-display rendering.
+
+The Magic Qube (Thermalright) is a 50-LED cooler display: two 7-segment
+digits (3 LEDs per segment, wire order c,d,e,g,b,a,f — right digit LED
+0-20, left 21-41) plus four corner metric indicators (LED 42-49, two LEDs
+each).  Both digits render one 2-digit value (left = tens, right = units)
+while a single corner indicator names the metric, rotating through four
+phases like CZ1.  The layout was mapped empirically on hardware.
+"""
+from __future__ import annotations
+
+import pytest
+
+from trcc.core.models import HardwareMetrics, LedStyle
+from trcc.services.led_segment import (
+    DISPLAYS,
+    MagicQubeDisplay,
+    _qube_digit_segmap,
+    get_display,
+)
+
+# 3-LED groups for the RIGHT digit (base 0), keyed by 7-seg label —
+# the hardware-validated wire order c, d, e, g, b, a, f.
+_RIGHT: dict[str, tuple[int, int, int]] = {
+    "c": (0, 1, 2), "d": (3, 4, 5), "e": (6, 7, 8), "g": (9, 10, 11),
+    "b": (12, 13, 14), "a": (15, 16, 17), "f": (18, 19, 20),
+}
+_INDICATORS = {42, 43, 44, 45, 46, 47, 48, 49}
+_BORDER = set(range(50, 65))   # contour LEDs, always lit
+
+
+def _lit(mask: list[bool]) -> set[int]:
+    return {i for i, v in enumerate(mask) if v}
+
+
+def _segments(labels: str, base: int = 0) -> set[int]:
+    out: set[int] = set()
+    for seg in labels:
+        out.update(i + base for i in _RIGHT[seg])
+    return out
+
+
+def test_registered_in_displays() -> None:
+    """MAGIC_QUBE resolves to a MagicQubeDisplay instance."""
+    assert isinstance(DISPLAYS[LedStyle.MAGIC_QUBE], MagicQubeDisplay)
+    assert isinstance(get_display(LedStyle.MAGIC_QUBE), MagicQubeDisplay)
+
+
+def test_mask_size_and_phase_count() -> None:
+    d = MagicQubeDisplay()
+    assert d.mask_size == 65
+    assert d.phase_count == 4
+
+
+def test_border_always_lit() -> None:
+    """The 15 contour LEDs (50-64) stay lit regardless of value or phase."""
+    d = MagicQubeDisplay()
+    for phase in range(4):
+        mask = d.compute_mask(HardwareMetrics(cpu_temp=0.0), phase=phase)
+        assert all(mask[i] for i in _BORDER)
+
+
+def test_segmap_follows_hardware_wire_order() -> None:
+    """The segment→LED map follows the hardware wire order c,d,e,g,b,a,f."""
+    assert _qube_digit_segmap(0) == _RIGHT
+    left = _qube_digit_segmap(21)
+    assert left["c"] == (21, 22, 23)
+    assert left["f"] == (39, 40, 41)
+
+
+def test_renders_two_digit_value_and_indicator() -> None:
+    """cpu_temp=52 → '5' left, '2' right, CPU°C lit.
+
+    Matches the hardware-validated render (qube.py 'show 5 2 cpuc').
+    """
+    d = MagicQubeDisplay()
+    mask = d.compute_mask(HardwareMetrics(cpu_temp=52.0), phase=0, temp_unit="C")
+    expected = _segments("abdeg") | _segments("acdfg", base=21) | {42, 43} | _BORDER
+    assert _lit(mask) == expected
+
+
+def test_leading_zero_suppressed_on_left_digit() -> None:
+    """A single-digit value blanks the tens digit (no leading zero)."""
+    d = MagicQubeDisplay()
+    lit = _lit(d.compute_mask(HardwareMetrics(cpu_temp=7.0), phase=0))
+    assert not any(21 <= i <= 41 for i in lit)             # left digit dark
+    assert (lit - _INDICATORS - _BORDER) == _segments("abc")  # '7' on the right
+
+
+@pytest.mark.parametrize("phase,indicator", [
+    (0, (42, 43)),
+    (1, (44, 45)),
+    (2, (46, 47)),
+    (3, (48, 49)),
+])
+def test_phase_rotation_lights_matching_indicator(
+    phase: int, indicator: tuple[int, int],
+) -> None:
+    """Each phase lights exactly its corner indicator."""
+    d = MagicQubeDisplay()
+    metrics = HardwareMetrics(
+        cpu_temp=33.0, gpu_temp=33.0, cpu_percent=33.0, gpu_usage=33.0,
+    )
+    mask = d.compute_mask(metrics, phase=phase)
+    assert (_lit(mask) & _INDICATORS) == set(indicator)
+
+
+def test_phase_wraps_modulo_four() -> None:
+    """Phase index wraps — phase 4 renders identically to phase 0."""
+    d = MagicQubeDisplay()
+    m = HardwareMetrics(cpu_temp=42.0)
+    assert d.compute_mask(m, phase=4) == d.compute_mask(m, phase=0)
+
+
+def test_value_clamped_to_99() -> None:
+    """Values above 99 clamp to '99' — the display has only two digits."""
+    d = MagicQubeDisplay()
+    over = _lit(d.compute_mask(HardwareMetrics(cpu_temp=150.0), phase=0))
+    assert over == _lit(d.compute_mask(HardwareMetrics(cpu_temp=99.0), phase=0))


### PR DESCRIPTION
## Summary

Adds support for the **Thermalright Magic Qube** LED cooler display (USB `0416:8001`).

The Magic Qube shares its USB id and PM byte (208) with the CZ1 but is a physically different **65-LED** device, and it answers the HID handshake with a non-standard header (`DC DD AA 01` instead of `DA DB DC DD`) — the only wire-level signal distinguishing it from a genuine CZ1. No reference implementation exists (it's absent from Thermalright's Windows TRCC 2.1.4/2.1.6), so the layout was reverse-engineered empirically on the hardware and validated end-to-end.

**Device layout (65 LEDs):**
- Two 7-segment digits, 3 LEDs per segment in wire order `c,d,e,g,b,a,f` (right digit LED 0–20, left 21–41)
- Four corner metric indicators, 2 LEDs each (42–49): CPU°C / GPU°C / GPU% / CPU%
- A 15-LED contour border (50–64)

Both digits show one 2-digit value (left tens / right units) with a 4-phase indicator rotation, like CZ1; the contour border is always lit and follows the effect colour.

**Changes:**
- New `LedStyle.MAGIC_QUBE` + `LedStyleSpec` (65 LEDs) + synthetic legacy id 13
- `MagicQubeDisplay` segment renderer (digits + indicator rotation + always-on border)
- Handshake fingerprint routing: `resolve_handshake()` matches the header first so `DC DD AA 01` → MAGIC_QUBE while a standard header still resolves via the PM registry (**CZ1 unaffected**); `resolve_model_name()` recovers it from the probe cache; `is_fingerprint_header()` silences the magic/cmd anomaly warnings for the recognised header
- `ConnectDevice` uses the adapter's fingerprint-resolved style instead of re-deriving from the PM byte
- GUI: page selector for the 4 metrics, `uc_screen_led` preview geometry (reusing the CZ1 deco, same labels), overlay page labels

**Notes:**
- Non-Magic-Qube devices are unaffected: `resolve_handshake` falls back to `resolve_pm`, and all registry additions are additive keys.
- Cosmetic follow-ups for someone with the C# tooling: dedicated preview/sidebar art (currently reuses CZ1 assets) and drawing the contour border in the on-screen preview.
- `pyright` reports 2 **pre-existing** errors in `uc_screen_led.py` (mouse-event `button`/`position`, lines 699/702) — present on `main`, in code this PR doesn't touch.

## Checklist

- [x] Tests pass — `PYTHONPATH=src pytest tests/ -q`: 2637 passed (the one unrelated failure is a pre-existing NVML test-isolation flake on non-NVIDIA hosts)
- [x] Linter clean — `ruff check .`
- [x] Tested on hardware — Magic Qube on my PC; digits, indicators, and border all verified live
- [x] New tests added — `tests/test_led_segment.py` + fingerprint/cache tests in `tests/test_led_pm_registry.py`
