### PR TITLE
Changed SaveTheme._store_background (theme.py:629) so video backgroun…

### DIFF
--- a/src/trcc/core/commands/theme.py
+++ b/src/trcc/core/commands/theme.py
@@ -125,6 +125,17 @@ class LoadTheme(Command[ThemeResult]):
         # Persist the absolute path — names are display strings, paths
         # are the stable reference RestoreLastTheme needs.
         app.settings.set_current_theme(self.key, str(theme.path.resolve()))
+        # Set the new theme BEFORE StopVideo: StopVideo's VideoStopped
+        # publish is handled synchronously by _DeviceRenderObserver, which
+        # re-renders using whatever theme is currently in ``active_themes``.
+        # If the old (about-to-be-replaced) theme were still active at that
+        # point, and it had a bundled video, DisplayService._resolve_background
+        # would decode + cache that video into MediaService as a side effect
+        # of the read — then LoadTheme's own render just below would see that
+        # stale playback and use it instead of the new theme's background
+        # (animated→static switches silently kept showing the old animation
+        # until a second click finally cleared it).
+        app.active_themes[self.key] = theme
         # Single source of truth for "stop the previous video + clear the
         # cloud-background override + invalidate the scene cache": ``StopVideo``
         # (publishes VideoStopped, clears background_path, unloads playback).
@@ -134,7 +145,6 @@ class LoadTheme(Command[ThemeResult]):
         # background to the theme's bundled one (StopVideo cleared the override).
         if self.reset_overrides:
             StopVideo(key=self.key).execute(app)
-        app.active_themes[self.key] = theme
         app.events.publish(ThemeLoaded(key=self.key, theme_name=theme.name))
         log.info(
             "LoadTheme: %s loaded — prior playback + cloud-bg override "

--- a/src/trcc/core/commands/theme.py
+++ b/src/trcc/core/commands/theme.py
@@ -635,20 +635,27 @@ class SaveTheme(Command[ThemeResult]):
         width: int,
         height: int,
     ) -> str | None:
-        """Link the resolved current background into the saved theme dir.
+        """Link (image) or copy (video) the resolved background into the
+        saved theme dir.
 
-        Every asset a saved theme uses is a SYMLINK into the shared data tree —
+        A static image background is a SYMLINK into the shared data tree —
         no bytes duplicated; only the DC/config (``trcc.json``) is a real copy
-        edited per save.  The background links in under its standard in-dir name
-        — ``00.png`` for an image, ``Theme.<ext>`` for a video — so the loader
-        finds it by convention and no manifest ref is needed (returns ``None``).
+        edited per save.  A video background is COPIED verbatim instead: a
+        symlinked ``Theme.<ext>`` would go dark if the library asset it
+        points at is later pruned/moved, and videos dedup poorly anyway (see
+        :meth:`_pick_asset` callers), so there's little to lose by making the
+        saved theme's own copy self-contained.  Either way the asset lands
+        under its standard in-dir name — ``00.png`` for an image,
+        ``Theme.<ext>`` for a video — so the loader finds it by convention and
+        no manifest ref is needed (returns ``None``).
 
-        Asset home (the symlink target): a catalog asset (cloud
+        Asset home (the symlink/copy source): a catalog asset (cloud
         ``cloud_theme_dir`` / user ``user_background_dir`` ``web/{w}{h}``) is
-        linked in place; a loose image/video is first stored into the user
-        library (deduped, native res) and the link points there.  On a
-        filesystem WITHOUT symlink support the asset is REFERENCED instead (the
-        ``web/{w}{h}/…`` ref is returned and the loader resolves it).
+        used in place; a loose image/video is first stored into the user
+        library (deduped, native res) and linked/copied from there.  On a
+        filesystem WITHOUT symlink support (image case) or an IO failure
+        (video case) the asset is REFERENCED instead (the ``web/{w}{h}/…``
+        ref is returned and the loader resolves it).
         ``DeviceSettings.background_path`` (override) wins over the source theme.
         """
         src = self._pick_asset(
@@ -684,6 +691,14 @@ class SaveTheme(Command[ThemeResult]):
             canonical = paths.user_background_dir(width, height) / Path(ref).name
 
         in_dir = f"Theme{ext}" if is_video else _LEGACY_BG_FILENAME
+        if is_video:
+            if self._try_copy(target / in_dir, canonical):
+                log.info("SaveTheme: background %s → copy %s → %s",
+                         src.name, in_dir, canonical)
+                return None
+            log.info("SaveTheme: background %s → reference %s (copy failed)",
+                     src.name, ref)
+            return ref
         if self._try_symlink(target / in_dir, canonical):
             log.info("SaveTheme: background %s → symlink %s → %s (no copy)",
                      src.name, in_dir, canonical)
@@ -778,6 +793,26 @@ class SaveTheme(Command[ThemeResult]):
         except OSError as e:
             log.info("SaveTheme: symlink %s → %s unavailable (%s) — referencing",
                      link, asset, e)
+            return False
+
+    @staticmethod
+    def _try_copy(dest: Path, asset: Path) -> bool:
+        """Copy *asset* to *dest* verbatim (used for video backgrounds).
+
+        True on success; False on an IO failure, so the caller falls back
+        to a manifest reference — same shape :meth:`_try_symlink` uses.
+        An existing entry at *dest* (a prior save's copy or symlink) is
+        replaced first.
+        """
+        import shutil
+        try:
+            if dest.is_symlink() or dest.exists():
+                dest.unlink()
+            shutil.copy2(asset, dest)
+            return True
+        except OSError as e:
+            log.info("SaveTheme: copy %s → %s failed (%s) — referencing",
+                     asset, dest, e)
             return False
 
     @staticmethod

--- a/src/trcc/core/commands/theme.py
+++ b/src/trcc/core/commands/theme.py
@@ -350,6 +350,15 @@ class LoadTheme(Command[ThemeResult]):
                      if sent else f"Theme '{theme.name}' rendered but send failed"),
         )
 
+def _clear_existing(path: Path) -> None:
+    """Remove any prior entry at *path* — a previous save's symlink or copy —
+    so a fresh link/copy can take its place.  Shared by ``_try_symlink`` and
+    ``_try_copy`` so the replace-then-place idiom lives in one spot.
+    """
+    if path.is_symlink() or path.exists():
+        path.unlink()
+
+
 @dataclass(frozen=True, slots=True)
 class SaveTheme(Command[ThemeResult]):
     """Save the device's CURRENT rendered state as a new theme directory.
@@ -796,8 +805,7 @@ class SaveTheme(Command[ThemeResult]):
         regardless of the theme dir's location.
         """
         try:
-            if link.is_symlink() or link.exists():
-                link.unlink()
+            _clear_existing(link)
             link.symlink_to(asset)
             return True
         except OSError as e:
@@ -816,8 +824,7 @@ class SaveTheme(Command[ThemeResult]):
         """
         import shutil
         try:
-            if dest.is_symlink() or dest.exists():
-                dest.unlink()
+            _clear_existing(dest)
             shutil.copy2(asset, dest)
             return True
         except OSError as e:

--- a/src/trcc/ui/api/display.py
+++ b/src/trcc/ui/api/display.py
@@ -317,6 +317,11 @@ def play_video(key: str, body: PlayVideoRequest,
         "api POST /devices/{key}/display/play-video: key=%s path=%s fps=%s",
         key, body.path, body.fps,
     )
+    # Persist the override BEFORE playing — mirrors ``LoadCloudTheme`` /
+    # ``SetBackground``.  Without this a later ``SaveTheme`` has nothing
+    # in ``DeviceSettings.background_path`` to bake in and the saved
+    # theme reloads with no background.
+    request.app.state.trcc.settings.set_background_path(key, body.path)
     result = request.app.state.trcc.dispatch(
         PlayVideo(key=key, path=Path(body.path), fps=body.fps),
     )
@@ -705,6 +710,14 @@ async def create_theme(
 
     animated = bg_suffix in _CREATE_THEME_VID_EXTS
     if animated:
+        # Persist the background override BEFORE playing it — mirrors
+        # ``LoadCloudTheme`` / ``SetBackground``.  Without this, a later
+        # ``SaveTheme`` has nothing in ``DeviceSettings.background_path``
+        # to bake into the saved theme dir and the reload comes back
+        # with no background.
+        request.app.state.trcc.settings.set_background_path(
+            key, str(bg_path),
+        )
         play_result = request.app.state.trcc.dispatch(
             PlayVideo(key=key, path=bg_path),
         )

--- a/src/trcc/ui/cli/display.py
+++ b/src/trcc/ui/cli/display.py
@@ -308,6 +308,11 @@ def play_video(
     log.info("cli display play-video: key=%s path=%s fps=%s", key, path, fps)
     app_obj = get_app()
     ensure_connected(app_obj, key)
+    # Persist the override BEFORE playing — mirrors ``LoadCloudTheme`` /
+    # ``SetBackground``.  Without this a later ``theme save`` has nothing
+    # in ``DeviceSettings.background_path`` to bake in and the saved
+    # theme reloads with no background.
+    app_obj.settings.set_background_path(key, str(path))
     result = app_obj.dispatch(PlayVideo(key=key, path=path, fps=fps))
     typer.echo(result.message)
     if not result.ok:

--- a/src/trcc/ui/gui/trcc_app.py
+++ b/src/trcc/ui/gui/trcc_app.py
@@ -36,7 +36,6 @@ from ...core.commands import (
     DeleteTheme,
     EnableOverlay,
     ListGpus,
-    PlayVideo,
     SetBackground,
     SetGpuDevice,
     SetHddEnabled,
@@ -1881,13 +1880,16 @@ class TRCCApp(QMainWindow):
         if self._screencast.active:
             self._app.dispatch(StopScreencast(key=h.device_key))
         h.is_background_active = False
-        # ``PlayVideo`` owns the full pipeline: decode, populate
-        # MediaService playback, publish ``VideoStarted`` so the
-        # handler's timer observer takes over.  Overlay-off is part of
-        # "play arbitrary video" UX — disable through the Command bus
-        # so persistence + render chain stays in sync.
+        # ``SetBackground`` persists the pick as the device's background
+        # override THEN delegates to ``PlayVideo`` (decode, populate
+        # MediaService playback, publish ``VideoStarted`` so the handler's
+        # timer observer takes over) — without the persist step a later
+        # ``SaveTheme`` has no override to bake in and the saved theme
+        # reloads without this video.  Overlay-off is part of "play
+        # arbitrary video" UX — disable through the Command bus so
+        # persistence + render chain stays in sync.
         self._app.dispatch(EnableOverlay(key=h.device_key, enabled=False))
-        result = self._app.dispatch(PlayVideo(
+        result = self._app.dispatch(SetBackground(
             key=h.device_key, path=Path(path),
         ))
         if not result.ok:
@@ -2140,10 +2142,14 @@ class TRCCApp(QMainWindow):
         self._hide_cutters()
         h = self._active_lcd()
         if zt_path and h:
-            # ``PlayVideo`` decodes the .zt, publishes ``VideoStarted``;
-            # handler observer starts the per-frame timer.  Same path
-            # cloud + local video themes take.
-            result = self._app.dispatch(PlayVideo(
+            # ``SetBackground`` persists the .zt as the device's
+            # background override (``DeviceSettings.background_path``)
+            # THEN delegates to ``PlayVideo`` for the decode/animate
+            # pipeline — same as the image cutter's ``_on_image_cut_done``.
+            # Dispatching ``PlayVideo`` directly here (the old code) left
+            # no override for ``SaveTheme`` to bake in, so a saved theme
+            # lost the video and reloaded with a black background.
+            result = self._app.dispatch(SetBackground(
                 key=h.device_key, path=Path(zt_path),
             ))
             if result.ok:

--- a/tests/test_theme_persistence.py
+++ b/tests/test_theme_persistence.py
@@ -878,15 +878,19 @@ def test_resave_onto_self_keeps_in_dir_background(
     assert app.themes.background_path(app.themes.load(saved)) is not None
 
 
-def test_save_theme_references_catalog_background_without_copying(
+def test_save_theme_references_catalog_image_background_without_copying(
     app: App, tmp_home: Path, user_theme_dir: Path,
 ) -> None:
-    """A background already in the cloud/user data catalog is REFERENCED by
-    ``web/{w}{h}/<name>`` — never copied into the theme dir.
+    """A STATIC IMAGE background already in the cloud/user data catalog is
+    REFERENCED by symlink — never copied into the theme dir.  (Video
+    backgrounds are the exception — see
+    ``test_saved_theme_video_background_plays_via_copy`` — a symlinked video
+    would go dark if the library asset is later pruned/moved, so those are
+    copied instead; this test covers the still-symlinked image case.)
 
     The data-ownership model: cloud downloads + user-library assets are
     shared, so the saved theme just points at the existing file (the
-    "symlink in config").  A re-save re-emits the same ref, so the
+    "symlink in config").  A re-save re-emits the same symlink, so the
     background survives overwrite without any copy.
     """
     import json as _json
@@ -894,22 +898,21 @@ def test_save_theme_references_catalog_background_without_copying(
     source = _write_theme_with_real_pngs(tmp_home, "src")
     app.active_themes[_TEST_DEVICE_KEY] = ThemeService().load(source)
 
-    # A cloud-downloaded video lives under cloud_theme_dir (data_dir/web/{w}{h}).
-    cloud_dir = app.platform.paths().cloud_theme_dir(*_TEST_RES)
-    cloud_dir.mkdir(parents=True, exist_ok=True)
-    cloud_video = cloud_dir / "a023.mp4"
-    video_bytes = b"\x00\x00\x00\x20ftypisom..." * 100
-    cloud_video.write_bytes(video_bytes)
-    app.settings.set_background_path(_TEST_DEVICE_KEY, str(cloud_video))
+    # A user-library image lives under user_background_dir (data_dir/web/{w}{h}).
+    lib_dir = app.platform.paths().user_background_dir(*_TEST_RES)
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    lib_image = lib_dir / "a023.png"
+    lib_image.write_bytes(_png_bytes(red=0x30))
+    app.settings.set_background_path(_TEST_DEVICE_KEY, str(lib_image))
 
     assert app.dispatch(SaveTheme(key=_TEST_DEVICE_KEY, name="catref")).ok
     saved = user_theme_dir / "catref"
     manifest = _json.loads((saved / "trcc.json").read_text(encoding="utf-8"))
     assert "background" not in manifest            # symlinked, not referenced…
-    assert (saved / "Theme.mp4").is_symlink()      # …and not copied
-    assert (saved / "Theme.mp4").resolve() == cloud_video.resolve()
+    assert (saved / "00.png").is_symlink()          # …and not copied
+    assert (saved / "00.png").resolve() == lib_image.resolve()
     assert (app.themes.background_path(app.themes.load(saved)).resolve()
-            == cloud_video.resolve())
+            == lib_image.resolve())
 
     # Re-save onto the same name → symlink persists, still no copy, no loss.
     assert app.dispatch(
@@ -917,7 +920,7 @@ def test_save_theme_references_catalog_background_without_copying(
     ).ok
     manifest2 = _json.loads((saved / "trcc.json").read_text(encoding="utf-8"))
     assert "background" not in manifest2
-    assert (saved / "Theme.mp4").resolve() == cloud_video.resolve()
+    assert (saved / "00.png").resolve() == lib_image.resolve()
 
 
 def test_save_theme_references_non_catalog_mask_override(
@@ -1013,28 +1016,36 @@ def test_video_path_resolves_referenced_video_background(app: App) -> None:
     assert app.themes.video_path(theme) == vid
 
 
-def test_saved_theme_video_background_plays_via_symlink(
+def test_saved_theme_video_background_plays_via_copy(
     app: App, tmp_home: Path, user_theme_dir: Path,
 ) -> None:
     """End-to-end for 'saved themes have no background remembered': a saved
-    theme with a VIDEO background symlinks it in as Theme.mp4, so video_path
-    finds it on reload and LoadTheme plays it — instead of the static path
-    handing an .mp4 to the image renderer (no background)."""
+    theme with a VIDEO background is COPIED in as Theme.mp4 (not symlinked —
+    a video source dedups poorly and a broken symlink would go dark if the
+    library asset is later pruned/moved), so video_path finds it on reload
+    and LoadTheme plays it — instead of the static path handing an .mp4 to
+    the image renderer (no background)."""
     source = _write_theme_with_real_pngs(tmp_home, "src")
     app.active_themes[_TEST_DEVICE_KEY] = ThemeService().load(source)
     cloud_dir = app.platform.paths().cloud_theme_dir(*_TEST_RES)
     cloud_dir.mkdir(parents=True, exist_ok=True)
     cloud_video = cloud_dir / "a023.mp4"
-    cloud_video.write_bytes(b"\x00\x00\x00\x20ftypisom" * 50)
+    video_bytes = b"\x00\x00\x00\x20ftypisom" * 50
+    cloud_video.write_bytes(video_bytes)
     app.settings.set_background_path(_TEST_DEVICE_KEY, str(cloud_video))
 
     assert app.dispatch(SaveTheme(key=_TEST_DEVICE_KEY, name="vid")).ok
     saved = user_theme_dir / "vid"
-    assert (saved / "Theme.mp4").is_symlink()
-    # Reload from disk → video_path finds the symlinked video → PlayVideo fires.
+    assert not (saved / "Theme.mp4").is_symlink()
+    assert (saved / "Theme.mp4").read_bytes() == video_bytes
+    # The saved theme survives the library source being removed — proof
+    # it's an independent copy, not a link that would go dark.
+    cloud_video.unlink()
+    # Reload from disk → video_path finds the copied video → PlayVideo fires.
     vp = app.themes.video_path(app.themes.load(saved))
     assert vp is not None
-    assert vp.resolve() == cloud_video.resolve()
+    assert vp.exists()
+    assert vp.read_bytes() == video_bytes
 
 
 def test_save_theme_inlines_mask_overlay_elements_into_manifest(


### PR DESCRIPTION
Changed SaveTheme._store_background (theme.py:629) so video backgrounds are copied (shutil.copy2) into the saved theme dir instead of symlinked — static image backgrounds (00.png) and masks (01.png) are unchanged and still symlink for dedup, since that still works well for them.

Added a _try_copy helper mirroring _try_symlink (same success/fallback-to-reference shape).
Falls back to a manifest reference if the copy itself fails (same graceful degradation the symlink path already had for filesystems without symlink support).
Updated the docstring to explain why video is the exception (poor dedup + a symlink going dark if the library asset is later pruned/moved — which is now a real, independent copy immune to that).
Updated the two tests that asserted Theme.mp4 was a symlink: test_saved_theme_video_background_plays_via_copy (renamed, now also proves the copy survives the source being deleted) and split the catalog-reference test to use an image asset (test_save_theme_references_catalog_image_background_without_copying), since "referenced without copying" is no longer true for video.

## Summary

Media save not being saved or loaded with themes causing a blackground on theme change or when you login and the app autostarts.  This fixes by ensureing that a Theme.zt file exists in the theme directory. This is done rather than symlinking to the precomputed version which should be treated as ephemeral.  This makes themes more portable across systems.

## Checklist

- [X] Tests pass (`pytest -v --tb=short`)
- [X] Linter clean (`ruff check .`)
- [X] Tested on hardware (if device-specific change)
- [X] New tests added (if adding functionality)
