### PR TITLE
fix(sensors): resolve Intel xe GPU temp by label, not fixed channel

### DIFF
--- a/src/trcc/adapters/sensors/hwmon.py
+++ b/src/trcc/adapters/sensors/hwmon.py
@@ -43,6 +43,16 @@ _CPU_DRIVERS = ("coretemp", "k10temp", "zenpower")
 _AMD_DRIVER = "amdgpu"
 _INTEL_DRIVERS = ("i915", "xe")
 
+# Label-preference order for GPU package temperature.  A fixed
+# read_temp(1) assumes the die sensor lives at temp1_input, but that
+# channel is driver-specific: the Intel `xe` driver (Arc) has no
+# temp1_input at all — its lowest channel is temp2 labelled "pkg", with
+# temp3="vram", temp4="mctrl", temp5="pcie" — so read_temp(1) reads a
+# nonexistent file and _read_int returns None silently.  Resolving by
+# tempN_label instead, package/die sensor first, fixes this without
+# hard-coding a per-driver channel number.
+_GPU_TEMP_LABELS = ("pkg", "gpu", "edge", "vram")
+
 
 # ── Sysfs I/O helpers ────────────────────────────────────────────────
 
@@ -91,6 +101,50 @@ class HwmonDevice:
         """tempN_input reports millidegrees C."""
         val = _read_int(self.path / f"temp{idx}_input")
         return val / 1000.0 if val is not None else None
+
+    def read_temp_labeled(
+        self, prefer: tuple[str, ...] = _GPU_TEMP_LABELS
+    ) -> float | None:
+        """Resolve a temperature by tempN_label instead of a fixed channel.
+
+        Some drivers don't populate temp1 — the Intel ``xe`` (Arc) driver's
+        lowest channel is temp2 labelled ``pkg`` — so a hard-coded
+        ``read_temp(1)`` reads a nonexistent ``temp1_input`` and returns None.
+        This scans the ``tempN_label`` files, returns the ``tempN_input``
+        matching the first preferred label (case-insensitive, exact match so
+        ``vram`` never picks up ``vram_ch_0``), and falls back to the lowest
+        readable ``tempN_input`` when no label matches (drivers that expose no
+        labels at all).  Returns None only when no channel is readable.
+        """
+        by_label: dict[str, int] = {}
+        indices: list[int] = []
+        for input_path in self.path.glob("temp*_input"):
+            try:
+                idx = int(input_path.name[len("temp"):-len("_input")])
+            except ValueError:
+                continue
+            indices.append(idx)
+            label = _read_text(self.path / f"temp{idx}_label")
+            if label is not None:
+                by_label[label.strip().lower()] = idx
+        for want in prefer:
+            idx = by_label.get(want)
+            if idx is None:
+                continue
+            val = self.read_temp(idx)
+            if val is not None:
+                log.debug("read_temp_labeled(%s): label %r -> temp%d = %.1f°C",
+                          self.driver, want, idx, val)
+                return val
+        for idx in sorted(indices):
+            val = self.read_temp(idx)
+            if val is not None:
+                log.debug("read_temp_labeled(%s): no preferred label matched, "
+                          "fell back to lowest channel temp%d = %.1f°C",
+                          self.driver, idx, val)
+                return val
+        log.debug("read_temp_labeled(%s): no readable temp*_input", self.driver)
+        return None
 
     def read_fan_rpm(self, idx: int = 1) -> int | None:
         return _read_int(self.path / f"fan{idx}_input")
@@ -384,7 +438,10 @@ class IntelGpu(GpuSource):
         return self._driver == "xe"
 
     def temp(self) -> float | None:
-        return self._hwmon.read_temp(1) if self._hwmon is not None else None
+        # Resolve by tempN_label — the xe (Arc) driver has no temp1_input
+        # (lowest channel is temp2="pkg"), so a fixed read_temp(1) reads a
+        # missing file and yields None (#gpu-temp-empty).
+        return self._hwmon.read_temp_labeled() if self._hwmon is not None else None
 
     def usage(self) -> float | None:
         # i915 exposes gt busy as `gt_cur_freq_mhz` / max ratio — approximate;

--- a/src/trcc/adapters/sensors/hwmon.py
+++ b/src/trcc/adapters/sensors/hwmon.py
@@ -87,6 +87,21 @@ def _read_float(path: Path) -> float | None:
         return None
 
 
+def _channel_index(input_name: str, prefix: str) -> int | None:
+    """Parse the channel number N from a ``{prefix}N_input`` hwmon filename
+    (``temp2_input`` → 2, ``fan1_input`` → 1), or None if it doesn't match.
+
+    Single parse for every ``{prefix}*_input`` scan (temp/fan/…) so the
+    filename convention lives in one place.
+    """
+    if not (input_name.startswith(prefix) and input_name.endswith("_input")):
+        return None
+    try:
+        return int(input_name[len(prefix):-len("_input")])
+    except ValueError:
+        return None
+
+
 # ── HwmonDevice — a wrapper around one /sys/class/hwmon/hwmonN dir ──
 
 
@@ -119,9 +134,8 @@ class HwmonDevice:
         by_label: dict[str, int] = {}
         indices: list[int] = []
         for input_path in self.path.glob("temp*_input"):
-            try:
-                idx = int(input_path.name[len("temp"):-len("_input")])
-            except ValueError:
+            idx = _channel_index(input_path.name, "temp")
+            if idx is None:
                 continue
             indices.append(idx)
             label = _read_text(self.path / f"temp{idx}_label")
@@ -531,9 +545,8 @@ def discover_fans(devices: list[HwmonDevice]) -> list[FanSource]:
     fans: list[FanSource] = []
     for dev in devices:
         for fan_input in sorted(dev.path.glob("fan*_input")):
-            try:
-                idx = int(fan_input.name.replace("fan", "").replace("_input", ""))
-            except ValueError:
+            idx = _channel_index(fan_input.name, "fan")
+            if idx is None:
                 continue
             label = _read_text(dev.path / f"fan{idx}_label")
             fans.append(HwmonFan(dev, idx, label))

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -359,6 +359,98 @@ def test_discover_dram_temp_skips_node_without_temp1(tmp_path: Path) -> None:
     assert hwmon.discover_dram_temp(devices) == []
 
 
+# ── Label-based GPU temperature resolution (Intel xe / Arc) ──────────
+
+
+def _hwmon_temps(root: Path, dirname: str, driver: str,
+                 channels: dict[int, tuple[int, str | None]]) -> hwmon.HwmonDevice:
+    """Build a hwmon node with arbitrary tempN channels.
+
+    ``channels`` maps channel index -> (millidegrees, label|None).  Unlike
+    ``_hwmon_dir`` this never writes a temp1 unless the caller asks for one,
+    so it can reproduce the xe layout (lowest channel is temp2="pkg").
+    """
+    d = root / dirname
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "name").write_text(f"{driver}\n")
+    for idx, (milli, label) in channels.items():
+        (d / f"temp{idx}_input").write_text(str(milli))
+        if label is not None:
+            (d / f"temp{idx}_label").write_text(f"{label}\n")
+    return hwmon.HwmonDevice(d)
+
+
+# The real Intel Arc Pro B70 (xe driver) channel layout: no temp1 at all,
+# temp2="pkg" is the package/die sensor.  (Trimmed from the 21 real channels.)
+_XE_CHANNELS = {
+    2: (52000, "pkg"),
+    3: (54000, "vram"),
+    4: (40000, "mctrl"),
+    5: (54000, "pcie"),
+    6: (50000, "vram_ch_0"),
+}
+
+
+def test_read_temp1_is_none_on_xe_layout(tmp_path: Path) -> None:
+    """Regression: the old read_temp(1) reads a nonexistent temp1_input."""
+    dev = _hwmon_temps(tmp_path, "hwmon8", "xe", _XE_CHANNELS)
+
+    assert dev.read_temp(1) is None
+
+
+def test_read_temp_labeled_prefers_pkg_on_xe(tmp_path: Path) -> None:
+    """Package sensor (temp2='pkg') resolves via label, not channel number."""
+    dev = _hwmon_temps(tmp_path, "hwmon8", "xe", _XE_CHANNELS)
+
+    assert dev.read_temp_labeled() == 52.0
+
+
+def test_read_temp_labeled_exact_match_not_substring(tmp_path: Path) -> None:
+    """'vram' must not select the 'vram_ch_0' channel when no earlier label
+    matches — exact label match only."""
+    dev = _hwmon_temps(tmp_path, "hwmon8", "xe", {
+        3: (54000, "vram"),        # exact 'vram'
+        6: (48000, "vram_ch_0"),   # must be ignored by the 'vram' preference
+    })
+
+    assert dev.read_temp_labeled() == 54.0
+
+
+def test_read_temp_labeled_falls_back_to_lowest_channel(tmp_path: Path) -> None:
+    """A driver exposing temps with no matching label uses the lowest channel."""
+    dev = _hwmon_temps(tmp_path, "hwmon0", "i915", {
+        1: (47000, None),
+        2: (61000, "junction"),   # not in the preference list
+    })
+
+    assert dev.read_temp_labeled() == 47.0
+
+
+def test_read_temp_labeled_none_when_no_channels(tmp_path: Path) -> None:
+    """No temp*_input at all → None (not a crash, not 0.0)."""
+    d = tmp_path / "hwmon8"
+    d.mkdir()
+    (d / "name").write_text("xe\n")
+
+    assert hwmon.HwmonDevice(d).read_temp_labeled() is None
+
+
+def test_intel_arc_temp_reads_package_via_label(tmp_path: Path) -> None:
+    """IntelGpu.temp() now surfaces the xe package temp instead of None."""
+    dev = _hwmon_temps(tmp_path, "hwmon8", "xe", _XE_CHANNELS)
+    gpu = hwmon.IntelGpu(0, dev, drm_card=None, driver="xe")
+
+    assert gpu.key == "intel:arc:0"
+    assert gpu.temp() == 52.0
+
+
+def test_intel_gpu_temp_none_without_hwmon(tmp_path: Path) -> None:
+    """A DRM-only iGPU (no hwmon node) still reports None, not a crash."""
+    gpu = hwmon.IntelGpu(0, None, drm_card=None, driver="i915")
+
+    assert gpu.temp() is None
+
+
 # ── Memory channel clock — SpdClock → memory:clock → mem_clock ───────
 
 


### PR DESCRIPTION
Fixes the empty `gpu:*` temperature keys on Intel Arc (`xe` driver).

### Root cause
`IntelGpu.temp()` called `read_temp(1)` → `temp1_input`. The `xe` driver has no `temp1_input`; its lowest channel is `temp2` labelled `pkg`, so `_read_int` returned `None` silently and every GPU temperature read empty despite discovery succeeding. Full write-up in #236.

### Change
- New `HwmonDevice.read_temp_labeled()` — scans `tempN_label`, returns the `tempN_input` for the first preferred label (`pkg`/`gpu`/`edge`/`vram`, exact case-insensitive match so `vram` never picks up `vram_ch_0`), and falls back to the lowest readable `tempN_input` for drivers that expose no labels.
- `IntelGpu.temp()` now uses it. **`fan()`/`clock()` deliberately left untouched** — see the unit-inconsistency note in #236.

### Verification
- Real hardware (Intel Arc Pro B70, `xe`): `IntelGpu.temp()` returns **52.0 °C (pkg)** where `read_temp(1)` returned `None`.
- 7 new tests in `tests/test_sensors.py` model the real xe channel layout (regression on `read_temp(1)`, label preference, exact-match vs `vram_ch_0`, no-label fallback, no-channel → `None`, `IntelGpu.temp()` end-to-end).
- `tests/test_sensors.py` 47 passed; sensors + chain + preference group 67 passed. `ruff` clean, `pyright` 0 errors on `hwmon.py`.

Closes #236.
