### PR TITLE
fix(report): use current settings and udev rule paths

### DIFF
--- a/src/trcc/adapters/diagnostics/debug_report.py
+++ b/src/trcc/adapters/diagnostics/debug_report.py
@@ -128,7 +128,7 @@ def build_debug_report(
     sensors, sensors_err = _collect_sensors(platform)
     powercap = _collect_powercap()
     settings_text, settings_err = _read_settings_file(
-        settings_path or platform.paths().config_dir() / "config.json",
+        settings_path or platform.paths().config_dir() / "trcc.json",
     )
     health = run_health_checks(platform)
     log_path = platform.paths().log_file()

--- a/src/trcc/adapters/diagnostics/health.py
+++ b/src/trcc/adapters/diagnostics/health.py
@@ -301,25 +301,27 @@ def check_qt_importable() -> HealthCheckResult:
 
 
 def check_udev_rules_linux() -> HealthCheckResult:
-    """Linux-only: look for installed udev rules under /etc/udev/rules.d/."""
+    """Linux-only: look for the canonical rule in standard install paths."""
     log.info("check_udev_rules_linux: called")
     if sys.platform != "linux":
         return HealthCheckResult(
             name="udev-rules", severity="OK",
             message="Not applicable on this OS",
         )
-    candidate_paths = [
-        Path("/etc/udev/rules.d/99-trcc.rules"),
-        Path("/etc/udev/rules.d/90-trcc.rules"),
-        Path("/lib/udev/rules.d/99-trcc.rules"),
-    ]
-    found = [p for p in candidate_paths if p.is_file()]
+    udev_rule_paths = (
+        Path("/etc/udev/rules.d/99-trcc-lcd.rules"),
+        Path("/run/udev/rules.d/99-trcc-lcd.rules"),
+        Path("/usr/local/lib/udev/rules.d/99-trcc-lcd.rules"),
+        Path("/usr/lib/udev/rules.d/99-trcc-lcd.rules"),
+        Path("/lib/udev/rules.d/99-trcc-lcd.rules"),
+    )
+    found = [p for p in udev_rule_paths if p.is_file()]
     if not found:
         return HealthCheckResult(
             name="udev-rules", severity="WARN",
-            message="No TRCC udev rules found under /etc/udev/rules.d/",
-            fix_hint="Run `trcc system setup` (or install via the distro "
-                     "package) to lay down /etc/udev/rules.d/99-trcc.rules",
+            message="No TRCC udev rules found",
+            fix_hint="Run `trcc system setup` or reinstall the distro package "
+                     "to install 99-trcc-lcd.rules",
         )
     return HealthCheckResult(
         name="udev-rules", severity="OK",

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -388,6 +388,23 @@ def test_debug_report_writes_to_disk(fake_platform, tmp_path: Path) -> None:
     assert "Paths" in body
 
 
+def test_debug_report_reads_canonical_settings_file(fake_platform) -> None:
+    config_dir = fake_platform.paths().config_dir()
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "config.json").write_text(
+        '{"source": "obsolete"}', encoding="utf-8",
+    )
+    (config_dir / "trcc.json").write_text(
+        '{"source": "canonical"}', encoding="utf-8",
+    )
+
+    report = build_debug_report(fake_platform)
+
+    assert report.settings_error == ""
+    assert '"source": "canonical"' in report.settings_json
+    assert "obsolete" not in report.settings_json
+
+
 def test_debug_report_captures_live_handshake(tmp_path: Path) -> None:
     """A connected LCD device's exact PM / SUB / fbl / resolution / raw bytes
     are captured live — the byte the report previously couldn't produce because

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -17,6 +17,7 @@ from trcc.adapters.diagnostics.health import (
     check_gpu_sensors,
     check_log_writable,
     check_python_version,
+    check_udev_rules_linux,
     package_install_hint,
     run_health_checks,
 )
@@ -258,6 +259,44 @@ def test_log_writable_check_passes_on_tmp_dir(
     paths = fake_platform.paths()
     result = check_log_writable(paths)
     assert result.severity == "OK"
+
+
+@pytest.mark.parametrize(
+    "installed_rule",
+    (
+        Path("/etc/udev/rules.d/99-trcc-lcd.rules"),
+        Path("/run/udev/rules.d/99-trcc-lcd.rules"),
+        Path("/usr/local/lib/udev/rules.d/99-trcc-lcd.rules"),
+        Path("/usr/lib/udev/rules.d/99-trcc-lcd.rules"),
+        Path("/lib/udev/rules.d/99-trcc-lcd.rules"),
+    ),
+)
+def test_udev_check_accepts_canonical_rule_in_standard_location(
+    installed_rule: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        health_mod.Path,
+        "is_file",
+        lambda path: path == installed_rule,
+    )
+
+    result = check_udev_rules_linux()
+
+    assert result.severity == "OK"
+    assert str(installed_rule) in result.message
+
+
+def test_udev_check_warns_with_current_rule_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(health_mod.Path, "is_file", lambda path: False)
+
+    result = check_udev_rules_linux()
+
+    assert result.severity == "WARN"
+    assert "99-trcc-lcd.rules" in result.fix_hint
+    assert "99-trcc.rules" not in result.fix_hint
 
 
 def test_run_health_checks_returns_full_report(fake_platform) -> None:


### PR DESCRIPTION
## Summary

Small cleanup for two misleading sections in `trcc report`. Both issues were spotted in the diagnostic output attached to #272.

Changes:
- read settings from `trcc.json` instead of the old `config.json` path
- look for `99-trcc-lcd.rules` in the standard system, runtime, local, and distro package locations
- update the hint from the obsolete `99-trcc.rules` name to the current `99-trcc-lcd.rules` filename
- add regression tests for both fixes

This prevents existing settings files and udev rules from being incorrectly reported as missing.

## Checklist

- [x] Tests pass (`pytest -v --tb=short`)
- [x] Linter clean (`ruff check .`)
- [x] Tested on hardware (if device-specific change)
- [x] New tests added (if adding functionality)
